### PR TITLE
Fix Sentry error reporting

### DIFF
--- a/internal/http/admin_auth.go
+++ b/internal/http/admin_auth.go
@@ -72,6 +72,7 @@ func handleLogin(a *app.App) http.HandlerFunc {
 		sessionID, err := auth.CreateSession(r.Context(), a.DB, user.ID, a.Config.Session.LifetimeMinutes)
 		if err != nil {
 			a.Logger.Error("failed to create session", "error", err)
+			captureError(r, err)
 			http.Redirect(w, r, "/admin/login?error=internal+error", http.StatusSeeOther)
 			return
 		}

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getsentry/sentry-go"
 	"github.com/go-chi/chi/v5"
 	"github.com/roots/wp-composer/internal/app"
 	"github.com/roots/wp-composer/internal/config"
@@ -22,6 +23,15 @@ import (
 )
 
 const perPage = 12
+
+// captureError reports a non-panic error to Sentry with the request's hub.
+func captureError(r *http.Request, err error) {
+	if hub := sentry.GetHubFromContext(r.Context()); hub != nil {
+		hub.CaptureException(err)
+	} else {
+		sentry.CaptureException(err)
+	}
+}
 
 type packageRow struct {
 	Type                    string
@@ -61,6 +71,7 @@ func handleIndex(a *app.App, tmpl *templateSet) http.HandlerFunc {
 		packages, total, err := queryPackages(r.Context(), a.DB, filters, page, perPage)
 		if err != nil {
 			a.Logger.Error("querying packages", "error", err)
+			captureError(r, err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
@@ -85,7 +96,7 @@ func handleIndex(a *app.App, tmpl *templateSet) http.HandlerFunc {
 
 		w.Header().Set("Cache-Control", "public, max-age=60, stale-while-revalidate=300")
 
-		render(w, tmpl.index, "layout", map[string]any{
+		render(w, r, tmpl.index, "layout", map[string]any{
 			"Packages":   packages,
 			"Filters":    filters,
 			"Page":       page,
@@ -118,6 +129,7 @@ func handleIndexPartial(a *app.App, tmpl *templateSet) http.HandlerFunc {
 		packages, total, err := queryPackages(r.Context(), a.DB, filters, page, perPage)
 		if err != nil {
 			a.Logger.Error("querying packages", "error", err)
+			captureError(r, err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
@@ -125,7 +137,7 @@ func handleIndexPartial(a *app.App, tmpl *templateSet) http.HandlerFunc {
 		totalPages := (total + perPage - 1) / perPage
 
 		w.Header().Set("X-Robots-Tag", "noindex")
-		render(w, tmpl.indexPartial, "package-results", map[string]any{
+		render(w, r, tmpl.indexPartial, "package-results", map[string]any{
 			"Packages":   packages,
 			"Filters":    filters,
 			"Page":       page,
@@ -137,7 +149,7 @@ func handleIndexPartial(a *app.App, tmpl *templateSet) http.HandlerFunc {
 
 func handleCompare(a *app.App, tmpl *templateSet) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		render(w, tmpl.compare, "layout", map[string]any{
+		render(w, r, tmpl.compare, "layout", map[string]any{
 			"AppURL":  a.Config.AppURL,
 			"CDNURL":  a.Config.R2.CDNPublicURL,
 			"OGImage": ogImageURL(a.Config, "social/default.png"),
@@ -147,7 +159,7 @@ func handleCompare(a *app.App, tmpl *templateSet) http.HandlerFunc {
 
 func handleRootsWordpress(a *app.App, tmpl *templateSet) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		render(w, tmpl.rootsWordpress, "layout", map[string]any{
+		render(w, r, tmpl.rootsWordpress, "layout", map[string]any{
 			"AppURL":         a.Config.AppURL,
 			"CDNURL":         a.Config.R2.CDNPublicURL,
 			"OGImage":        ogImageURL(a.Config, "social/default.png"),
@@ -172,7 +184,7 @@ func handleDetail(a *app.App, tmpl *templateSet) http.HandlerFunc {
 			} else {
 				w.WriteHeader(http.StatusNotFound)
 			}
-			render(w, tmpl.notFound, "layout", map[string]any{"Gone": gone, "CDNURL": a.Config.R2.CDNPublicURL})
+			render(w, r, tmpl.notFound, "layout", map[string]any{"Gone": gone, "CDNURL": a.Config.R2.CDNPublicURL})
 			return
 		}
 
@@ -237,7 +249,7 @@ func handleDetail(a *app.App, tmpl *templateSet) http.HandlerFunc {
 			},
 		}
 
-		render(w, tmpl.detail, "layout", map[string]any{
+		render(w, r, tmpl.detail, "layout", map[string]any{
 			"Package":  pkg,
 			"Versions": versions,
 			"AppURL":   a.Config.AppURL,
@@ -265,7 +277,7 @@ func handleAdminDashboard(a *app.App, tmpl *templateSet) http.HandlerFunc {
 		s.CurrentBuild = currentBuild
 		stats["Stats"] = s
 
-		render(w, tmpl.adminDashboard, "admin_layout", stats)
+		render(w, r, tmpl.adminDashboard, "admin_layout", stats)
 	}
 }
 
@@ -284,13 +296,14 @@ func handleAdminPackages(a *app.App, tmpl *templateSet) http.HandlerFunc {
 		packages, total, err := queryAdminPackages(r.Context(), a.DB, filters, page, 50)
 		if err != nil {
 			a.Logger.Error("querying admin packages", "error", err)
+			captureError(r, err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
 
 		totalPages := (total + 50 - 1) / 50
 
-		render(w, tmpl.adminPackages, "admin_layout", map[string]any{
+		render(w, r, tmpl.adminPackages, "admin_layout", map[string]any{
 			"Packages":   packages,
 			"Filters":    filters,
 			"Page":       page,
@@ -305,6 +318,7 @@ func handleAdminBuilds(a *app.App, tmpl *templateSet) http.HandlerFunc {
 		builds, err := queryBuilds(r.Context(), a.DB)
 		if err != nil {
 			a.Logger.Error("querying builds", "error", err)
+			captureError(r, err)
 		}
 
 		currentID, _ := deploy.CurrentBuildID("storage/repository")
@@ -314,7 +328,7 @@ func handleAdminBuilds(a *app.App, tmpl *templateSet) http.HandlerFunc {
 			}
 		}
 
-		render(w, tmpl.adminBuilds, "admin_layout", map[string]any{
+		render(w, r, tmpl.adminBuilds, "admin_layout", map[string]any{
 			"Builds": builds,
 		})
 	}
@@ -327,7 +341,7 @@ var logFiles = map[string]string{
 
 func handleAdminLogs(tmpl *templateSet) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		render(w, tmpl.adminLogs, "admin_layout", nil)
+		render(w, r, tmpl.adminLogs, "admin_layout", nil)
 	}
 }
 
@@ -513,6 +527,7 @@ func generatePackageOG(a *app.App, pkg *packageDetail) {
 	pngBytes, err := og.GeneratePackageImage(data)
 	if err != nil {
 		a.Logger.Error("generating OG image", "package", pkg.Name, "error", err)
+		sentry.CaptureException(err)
 		return
 	}
 
@@ -520,6 +535,7 @@ func generatePackageOG(a *app.App, pkg *packageDetail) {
 	key := "social/" + pkg.Type + "/" + pkg.Name + ".png"
 	if err := uploader.Upload(context.Background(), key, pngBytes); err != nil {
 		a.Logger.Error("uploading OG image", "package", pkg.Name, "error", err)
+		sentry.CaptureException(err)
 		return
 	}
 

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -23,10 +23,10 @@ func NewRouter(a *app.App) chi.Router {
 		r.Use(middleware.RealIP)
 	}
 
+	r.Use(middleware.Recoverer)
+
 	sentryMiddleware := sentryhttp.New(sentryhttp.Options{Repanic: true})
 	r.Use(sentryMiddleware.Handle)
-
-	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(60 * time.Second))
 
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -100,7 +100,7 @@ func NewRouter(a *app.App) chi.Router {
 
 	r.NotFound(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		render(w, tmpl.notFound, "layout", map[string]any{"Gone": false, "CDNURL": a.Config.R2.CDNPublicURL})
+		render(w, r, tmpl.notFound, "layout", map[string]any{"Gone": false, "CDNURL": a.Config.R2.CDNPublicURL})
 	})
 
 	return r

--- a/internal/http/seo.go
+++ b/internal/http/seo.go
@@ -36,6 +36,7 @@ func handleFeed(a *app.App) http.HandlerFunc {
 			cached, err = generateFeed(r.Context(), a.DB, a.Config.AppURL)
 			if err != nil {
 				a.Logger.Error("generating feed", "error", err)
+				captureError(r, err)
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 				return
 			}
@@ -209,6 +210,7 @@ func handleSitemapIndex(a *app.App, data *sitemapData) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := ensureSitemapData(r.Context(), a, data); err != nil {
 			a.Logger.Error("generating sitemap", "error", err)
+			captureError(r, err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
@@ -227,6 +229,7 @@ func handleSitemapPages(a *app.App, data *sitemapData) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := ensureSitemapData(r.Context(), a, data); err != nil {
 			a.Logger.Error("generating sitemap", "error", err)
+			captureError(r, err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
@@ -245,6 +248,7 @@ func handleSitemapPackages(a *app.App, data *sitemapData) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := ensureSitemapData(r.Context(), a, data); err != nil {
 			a.Logger.Error("generating sitemap", "error", err)
+			captureError(r, err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/getsentry/sentry-go"
 	"github.com/roots/wp-composer/internal/app"
 )
 
@@ -57,6 +58,8 @@ func ListenAndServe(a *app.App) error {
 		a.Logger.Info("shutting down", "signal", sig.String())
 	case err := <-errCh:
 		if err != nil {
+			sentry.CaptureException(err)
+			sentry.Flush(2 * time.Second)
 			return err
 		}
 	}
@@ -65,7 +68,10 @@ func ListenAndServe(a *app.App) error {
 	defer cancel()
 
 	if err := srv.Shutdown(ctx); err != nil {
-		return fmt.Errorf("shutdown: %w", err)
+		shutdownErr := fmt.Errorf("shutdown: %w", err)
+		sentry.CaptureException(shutdownErr)
+		sentry.Flush(2 * time.Second)
+		return shutdownErr
 	}
 
 	a.Logger.Info("server stopped")

--- a/internal/http/templates.go
+++ b/internal/http/templates.go
@@ -59,9 +59,10 @@ func parse(files ...string) *template.Template {
 	return template.Must(template.New("").Funcs(funcMap).ParseFS(templateFS, files...))
 }
 
-func render(w http.ResponseWriter, tmpl *template.Template, name string, data any) {
+func render(w http.ResponseWriter, r *http.Request, tmpl *template.Template, name string, data any) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := tmpl.ExecuteTemplate(w, name, data); err != nil {
+		captureError(r, err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
## Summary
- Swap Recoverer/sentryhttp middleware order so Sentry catches panics before Recoverer swallows them (also fixes "superfluous WriteHeader" log spam)
- Add `captureError()` helper using request-scoped Sentry hub at all handled error paths (handlers, SEO, admin auth, template render)
- Capture server startup/shutdown errors directly via `sentry.CaptureException`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./internal/http/...` clean
- [x] `golangci-lint run ./internal/http/...` — 0 issues
- [x] `make test` — all tests pass
- [ ] Deploy and verify errors appear in Sentry dashboard
- [ ] Verify "superfluous WriteHeader" log spam is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)