### PR TITLE
Add automatic R2 cleanup to pipeline

### DIFF
--- a/cmd/wpcomposer/cmd/deploy.go
+++ b/cmd/wpcomposer/cmd/deploy.go
@@ -139,7 +139,7 @@ func init() {
 	f.Lookup("rollback").NoOptDefVal = " " // allows --rollback without =value
 	f.Bool("cleanup", false, "remove old builds beyond retention")
 	f.Bool("r2-cleanup", false, "also clean stale files from R2 during cleanup")
-	f.Int("retain", 3, "number of recent builds to retain (beyond current)")
+	f.Int("retain", 5, "number of recent builds to retain (beyond current)")
 	f.Int("grace-hours", 24, "hours to keep old releases on R2 after deploy")
 	f.Bool("to-r2", false, "sync build to R2")
 	rootCmd.AddCommand(deployCmd)

--- a/cmd/wpcomposer/cmd/pipeline.go
+++ b/cmd/wpcomposer/cmd/pipeline.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
+	"github.com/roots/wp-composer/internal/deploy"
 	"github.com/spf13/cobra"
 )
 
@@ -58,6 +60,22 @@ func executePipelineSteps(cmd *cobra.Command, ctx context.Context, skipDiscover,
 		deployCmd.SetContext(ctx)
 		if err := runDeploy(deployCmd, nil); err != nil {
 			return fmt.Errorf("deploy: %w", err)
+		}
+
+		// Clean up old builds after a successful deploy.
+		repoDir := filepath.Join("storage", "repository")
+		if removed, err := deploy.Cleanup(repoDir, 5, application.Logger); err != nil {
+			application.Logger.Warn("pipeline: local cleanup failed", "error", err)
+		} else if removed > 0 {
+			application.Logger.Info("pipeline: local cleanup done", "removed", removed)
+		}
+
+		if application.Config.R2.Enabled {
+			if removed, err := deploy.CleanupR2(ctx, application.Config.R2, 24, 5, application.Logger); err != nil {
+				application.Logger.Warn("pipeline: R2 cleanup failed", "error", err)
+			} else if removed > 0 {
+				application.Logger.Info("pipeline: R2 cleanup done", "objects_removed", removed)
+			}
 		}
 	}
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -77,9 +77,9 @@ wpcomposer deploy --cleanup --r2-cleanup --grace-hours 6
 - Validates build artifacts before any sync or promotion.
 - `--to-r2` uploads to a versioned release prefix (`releases/<build-id>/`), rewrites root `packages.json` as the atomic pointer swap, then promotes locally. If R2 sync fails, the local symlink is not updated.
 - Rollback validates target build, syncs to R2 if enabled, then promotes.
-- `--cleanup` removes old local builds beyond retention (default: 3 beyond current).
+- `--cleanup` removes old local builds beyond retention (default: 5 beyond current).
 - `--r2-cleanup` removes stale release prefixes from R2 (must be combined with `--cleanup`). Reads R2 state directly — no local filesystem dependency.
-- `--retain N` controls how many releases to keep beyond current.
+- `--retain N` controls how many releases to keep beyond current (minimum: 5).
 - `--grace-hours N` keeps releases younger than N hours (default: 24).
 
 ### Full Pipeline
@@ -91,7 +91,7 @@ wpcomposer pipeline --skip-deploy
 wpcomposer pipeline --discover-source=config
 ```
 
-Runs discover → update → build → deploy sequentially, stopping on failure.
+Runs discover → update → build → deploy sequentially, stopping on failure. After a successful deploy, automatically cleans up old local builds and stale R2 releases (keeps live + 5 most recent + 24h grace window). Cleanup is best-effort — failures are logged as warnings but do not fail the pipeline.
 
 ### Aggregate Installs
 

--- a/docs/r2-deployment.md
+++ b/docs/r2-deployment.md
@@ -126,14 +126,13 @@ aws s3 ls s3://wp-composer-repo/releases/ --profile r2 --endpoint-url https://<a
 
 ### Cleanup stale R2 releases
 
-Old release prefixes accumulate on R2 across deploys. Use the built-in cleanup:
+The `wpcomposer pipeline` command automatically cleans up old R2 releases after each successful deploy, keeping the live release + 5 most recent + releases within a 24-hour grace window. Cleanup is best-effort — failures are logged as warnings but do not fail the pipeline. If cleanup errors persist, run manual cleanup to investigate.
+
+For manual cleanup:
 
 ```bash
-# Remove R2 releases beyond retention (keeps live + 3 most recent + within grace period)
+# Remove R2 releases beyond retention (keeps live + 5 most recent + within grace period)
 wpcomposer deploy --cleanup --r2-cleanup
-
-# Keep more releases (current + 5 recent)
-wpcomposer deploy --cleanup --r2-cleanup --retain 5
 
 # Shorter grace period (default 24 hours)
 wpcomposer deploy --cleanup --r2-cleanup --grace-hours 6
@@ -141,7 +140,7 @@ wpcomposer deploy --cleanup --r2-cleanup --grace-hours 6
 
 `--r2-cleanup` is required — plain `--cleanup` only removes local build directories. The cleanup reads R2 state directly (no local filesystem dependency), identifies release prefixes, and deletes those outside the keep set. It also deletes legacy flat files (anything not under `releases/` except root `packages.json`).
 
-The keep set is: live release (from root `packages.json`) + releases within `--grace-hours` + top `--retain` most recent.
+The keep set is: live release (from root `packages.json`) + releases within `--grace-hours` + top `--retain` most recent. The retain count has a hard minimum of 5 — even if `--retain` is set lower, at least 5 recent releases are always preserved.
 
 ## Rollback
 

--- a/internal/deploy/local.go
+++ b/internal/deploy/local.go
@@ -69,8 +69,9 @@ func Rollback(repoDir, targetID string, logger *slog.Logger) (string, error) {
 
 // Cleanup removes old builds, keeping the current build and up to retainCount others.
 func Cleanup(repoDir string, retainCount int, logger *slog.Logger) (int, error) {
-	if retainCount < 1 {
-		retainCount = 3
+	if retainCount < 5 {
+		logger.Warn("retain count below minimum, clamping to 5", "requested", retainCount)
+		retainCount = 5
 	}
 
 	currentID, _ := CurrentBuildID(repoDir)

--- a/internal/deploy/local_test.go
+++ b/internal/deploy/local_test.go
@@ -89,15 +89,19 @@ func TestRollbackToSpecific(t *testing.T) {
 
 func TestCleanup(t *testing.T) {
 	repoDir := t.TempDir()
+	createTestBuild(t, repoDir, "20260313-080000")
+	createTestBuild(t, repoDir, "20260313-090000")
 	createTestBuild(t, repoDir, "20260313-100000")
 	createTestBuild(t, repoDir, "20260313-110000")
 	createTestBuild(t, repoDir, "20260313-120000")
 	createTestBuild(t, repoDir, "20260313-130000")
 	createTestBuild(t, repoDir, "20260313-140000")
+	createTestBuild(t, repoDir, "20260313-150000")
 
-	_ = Promote(repoDir, "20260313-140000", slog.Default())
+	_ = Promote(repoDir, "20260313-150000", slog.Default())
 
-	removed, err := Cleanup(repoDir, 2, slog.Default())
+	// retainCount is clamped to a minimum of 5
+	removed, err := Cleanup(repoDir, 5, slog.Default())
 	if err != nil {
 		t.Fatalf("cleanup: %v", err)
 	}
@@ -106,8 +110,8 @@ func TestCleanup(t *testing.T) {
 	}
 
 	builds, _ := ListBuilds(repoDir)
-	if len(builds) != 3 {
-		t.Errorf("remaining builds = %d, want 3 (current + 2 retained)", len(builds))
+	if len(builds) != 6 {
+		t.Errorf("remaining builds = %d, want 6 (current + 5 retained)", len(builds))
 	}
 }
 

--- a/internal/deploy/r2.go
+++ b/internal/deploy/r2.go
@@ -266,8 +266,9 @@ func CleanupR2(ctx context.Context, cfg config.R2Config, graceHours, retainCount
 }
 
 func cleanupR2(ctx context.Context, client r2API, bucket string, graceHours, retainCount int, logger *slog.Logger) (int, error) {
-	if retainCount < 1 {
-		retainCount = 3
+	if retainCount < 5 {
+		logger.Warn("retain count below minimum, clamping to 5", "requested", retainCount)
+		retainCount = 5
 	}
 	if graceHours < 0 {
 		graceHours = 24


### PR DESCRIPTION
## Summary

- Pipeline now runs local + R2 cleanup after each successful deploy (best-effort, won't fail the pipeline)
- Retain count raised from 3 → 5 with a hard minimum floor of 5 across all code paths (CLI flag default, local cleanup, R2 cleanup)
- Warns in logs when an explicit `--retain` value is clamped to the minimum
- Updated docs in operations.md and r2-deployment.md to reflect new defaults and best-effort semantics

## Test plan

- [x] `make test` passes (cleanup test updated for new retain floor)
- [x] `make lint` and `gofmt` clean
- [ ] Deploy to staging and verify pipeline logs show cleanup step
- [ ] Verify `wpcomposer deploy --cleanup --r2-cleanup --retain 1` logs the clamping warning and keeps 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)