### PR TITLE
Add admin build trigger and readable timestamps

### DIFF
--- a/cmd/wpcomposer/cmd/pipeline.go
+++ b/cmd/wpcomposer/cmd/pipeline.go
@@ -3,12 +3,73 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/roots/wp-composer/internal/deploy"
 	"github.com/spf13/cobra"
 )
+
+const pipelineLockPath = "storage/pipeline.lock"
+
+// pipelineLockFile holds the lock file reference for the lifetime of the process,
+// preventing the GC finalizer from closing the fd and releasing the lock.
+var pipelineLockFile *os.File
+
+// acquirePipelineLock ensures only one pipeline runs at a time.
+func acquirePipelineLock() error {
+	return acquireLock(pipelineLockPath)
+}
+
+// acquireLock acquires an exclusive file lock at lockPath. If PIPELINE_LOCK_FD is
+// set, the lock is expected to have been inherited from the parent process via fd
+// passing; the inherited fd is validated for both inode identity and lock ownership.
+func acquireLock(lockPath string) error {
+	if v := os.Getenv("PIPELINE_LOCK_FD"); v != "" {
+		fd, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid PIPELINE_LOCK_FD: %w", err)
+		}
+		pipelineLockFile = os.NewFile(uintptr(fd), lockPath)
+		if pipelineLockFile == nil {
+			return fmt.Errorf("PIPELINE_LOCK_FD=%d: invalid file descriptor", fd)
+		}
+
+		// Verify the inherited fd points to the actual lock file (inode match).
+		var fdStat, pathStat syscall.Stat_t
+		if err := syscall.Fstat(fd, &fdStat); err != nil {
+			return fmt.Errorf("PIPELINE_LOCK_FD=%d: fstat failed: %w", fd, err)
+		}
+		if err := syscall.Stat(lockPath, &pathStat); err != nil {
+			return fmt.Errorf("pipeline lock stat: %w", err)
+		}
+		if fdStat.Dev != pathStat.Dev || fdStat.Ino != pathStat.Ino {
+			return fmt.Errorf("PIPELINE_LOCK_FD=%d does not refer to %s", fd, lockPath)
+		}
+
+		// Verify this fd actually holds the lock. Re-locking our own fd is a
+		// no-op in flock, so LOCK_EX|LOCK_NB succeeds if we hold it, and fails
+		// with EWOULDBLOCK if a different open file description holds it.
+		if err := syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+			return fmt.Errorf("PIPELINE_LOCK_FD=%d does not hold the pipeline lock", fd)
+		}
+		return nil
+	}
+
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("pipeline lock: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("pipeline already running (could not acquire %s)", lockPath)
+	}
+	pipelineLockFile = f
+	return nil
+}
 
 var pipelineCmd = &cobra.Command{
 	Use:   "pipeline",
@@ -17,6 +78,13 @@ var pipelineCmd = &cobra.Command{
 }
 
 func runPipeline(cmd *cobra.Command, args []string) error {
+	// Acquire a system-wide file lock so only one pipeline runs at a time.
+	// When triggered from the admin UI, the parent process passes the already-locked
+	// fd via PIPELINE_LOCK_FD so the lock transfers atomically with no TOCTOU gap.
+	if err := acquirePipelineLock(); err != nil {
+		return err
+	}
+
 	skipDiscover, _ := cmd.Flags().GetBool("skip-discover")
 	skipDeploy, _ := cmd.Flags().GetBool("skip-deploy")
 	discoverSource, _ := cmd.Flags().GetString("discover-source")

--- a/cmd/wpcomposer/cmd/pipeline_lock_test.go
+++ b/cmd/wpcomposer/cmd/pipeline_lock_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func resetLockState() {
+	if pipelineLockFile != nil {
+		_ = syscall.Flock(int(pipelineLockFile.Fd()), syscall.LOCK_UN)
+		_ = pipelineLockFile.Close()
+		pipelineLockFile = nil
+	}
+	_ = os.Unsetenv("PIPELINE_LOCK_FD")
+}
+
+func TestAcquireLock_BlocksSecondCaller(t *testing.T) {
+	t.Cleanup(resetLockState)
+
+	lockPath := filepath.Join(t.TempDir(), "pipeline.lock")
+
+	if err := acquireLock(lockPath); err != nil {
+		t.Fatalf("first lock acquisition failed: %v", err)
+	}
+
+	// Hold the lock in pipelineLockFile; save and swap it out so the second
+	// call creates its own fd.
+	held := pipelineLockFile
+	pipelineLockFile = nil
+	t.Cleanup(func() {
+		_ = syscall.Flock(int(held.Fd()), syscall.LOCK_UN)
+		_ = held.Close()
+	})
+
+	err := acquireLock(lockPath)
+	if err == nil {
+		t.Fatal("expected second lock acquisition to fail, but it succeeded")
+	}
+}
+
+func TestAcquireLock_InheritedFD_Valid(t *testing.T) {
+	t.Cleanup(resetLockState)
+
+	lockPath := filepath.Join(t.TempDir(), "pipeline.lock")
+
+	// Simulate parent: open and lock the file.
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	})
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("flock failed: %v", err)
+	}
+
+	t.Setenv("PIPELINE_LOCK_FD", fmt.Sprintf("%d", f.Fd()))
+	if err := acquireLock(lockPath); err != nil {
+		t.Fatalf("inherited fd should be accepted: %v", err)
+	}
+}
+
+func TestAcquireLock_InheritedFD_WrongFile(t *testing.T) {
+	t.Cleanup(resetLockState)
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "pipeline.lock")
+
+	// Create the lock file so stat succeeds.
+	if err := os.WriteFile(lockPath, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open a different file and lock it.
+	other, err := os.CreateTemp(dir, "other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = other.Close() })
+	_ = syscall.Flock(int(other.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+
+	t.Setenv("PIPELINE_LOCK_FD", fmt.Sprintf("%d", other.Fd()))
+	err = acquireLock(lockPath)
+	if err == nil {
+		t.Fatal("expected rejection for fd pointing to wrong file")
+	}
+}
+
+func TestAcquireLock_InheritedFD_NotLocked(t *testing.T) {
+	t.Cleanup(resetLockState)
+
+	lockPath := filepath.Join(t.TempDir(), "pipeline.lock")
+
+	// Open the correct file but don't lock it.
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	// Hold the lock from a *different* fd to simulate a real pipeline running.
+	holder, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Flock(int(holder.Fd()), syscall.LOCK_UN)
+		_ = holder.Close()
+	})
+	if err := syscall.Flock(int(holder.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("flock failed: %v", err)
+	}
+
+	// f points to the right file but doesn't hold the lock — should be rejected.
+	t.Setenv("PIPELINE_LOCK_FD", fmt.Sprintf("%d", f.Fd()))
+	err = acquireLock(lockPath)
+	if err == nil {
+		t.Fatal("expected rejection for fd that doesn't hold the lock")
+	}
+}

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -328,9 +330,65 @@ func handleAdminBuilds(a *app.App, tmpl *templateSet) http.HandlerFunc {
 			}
 		}
 
-		render(w, r, tmpl.adminBuilds, "admin_layout", map[string]any{
-			"Builds": builds,
-		})
+		data := map[string]any{
+			"Builds":    builds,
+			"Triggered": r.URL.Query().Get("triggered") == "1",
+			"Error":     r.URL.Query().Get("error"),
+		}
+		if len(builds) > 0 {
+			data["LastBuildStartedAt"] = builds[0].StartedAt
+		}
+
+		render(w, r, tmpl.adminBuilds, "admin_layout", data)
+	}
+}
+
+const pipelineLockPath = "storage/pipeline.lock"
+
+func handleTriggerBuild(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		self, err := os.Executable()
+		if err != nil {
+			a.Logger.Error("failed to find executable", "error", err)
+			http.Redirect(w, r, "/admin/builds?error=internal+error", http.StatusSeeOther)
+			return
+		}
+
+		// Acquire the lock before spawning so we know the status is accurate.
+		lockFile, err := os.OpenFile(pipelineLockPath, os.O_CREATE|os.O_RDWR, 0644)
+		if err != nil {
+			a.Logger.Error("failed to open pipeline lock", "error", err)
+			http.Redirect(w, r, "/admin/builds?error=internal+error", http.StatusSeeOther)
+			return
+		}
+		if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+			_ = lockFile.Close()
+			http.Redirect(w, r, "/admin/builds?error=build+already+running", http.StatusSeeOther)
+			return
+		}
+
+		// Pass the locked fd to the child via ExtraFiles (fd 3) so the lock
+		// transfers atomically. The child detects PIPELINE_LOCK_FD and skips
+		// its own acquisition.
+		go func() {
+			defer func() {
+				_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+				_ = lockFile.Close()
+			}()
+
+			cmd := exec.Command(self, "pipeline")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			cmd.ExtraFiles = []*os.File{lockFile} // fd 3 in child
+			cmd.Env = append(os.Environ(), "PIPELINE_LOCK_FD=3")
+			if err := cmd.Run(); err != nil {
+				a.Logger.Error("triggered pipeline failed", "error", err)
+			} else {
+				a.Logger.Info("triggered pipeline completed")
+			}
+		}()
+
+		http.Redirect(w, r, "/admin/builds?triggered=1", http.StatusSeeOther)
 	}
 }
 

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -91,6 +91,7 @@ func NewRouter(a *app.App) chi.Router {
 		r.Get("/", handleAdminDashboard(a, tmpl))
 		r.Get("/packages", handleAdminPackages(a, tmpl))
 		r.Get("/builds", handleAdminBuilds(a, tmpl))
+		r.Post("/builds/trigger", handleTriggerBuild(a))
 		r.Get("/logs", handleAdminLogs(tmpl))
 
 		r.Get("/logs/stream", noTimeout(handleAdminLogStream(a)))

--- a/internal/http/templates.go
+++ b/internal/http/templates.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 //go:embed templates/*.html
@@ -24,6 +25,8 @@ var funcMap = template.FuncMap{
 	"paginatePartial":   paginatePartialURL,
 	"adminPaginate":     adminPaginateURL,
 	"jsonLD":            jsonLD,
+	"formatCST":         formatCST,
+	"timeAgo":           timeAgo,
 }
 
 type templateSet struct {
@@ -188,4 +191,52 @@ func jsonLD(data any) template.HTML {
 		return ""
 	}
 	return template.HTML(`<script type="application/ld+json">` + string(b) + `</script>`)
+}
+
+var cst = func() *time.Location {
+	loc, err := time.LoadLocation("America/Chicago")
+	if err != nil {
+		return time.FixedZone("CST", -6*60*60)
+	}
+	return loc
+}()
+
+// formatCST converts an RFC3339 string to "Jan 2, 3:04 PM" in America/Chicago.
+func formatCST(raw string) string {
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return raw
+	}
+	return t.In(cst).Format("Jan 2, 3:04 PM")
+}
+
+// timeAgo returns a human-readable relative time like "23 minutes ago".
+func timeAgo(raw string) string {
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return raw
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		m := int(d.Minutes())
+		if m == 1 {
+			return "1 minute ago"
+		}
+		return fmt.Sprintf("%d minutes ago", m)
+	case d < 24*time.Hour:
+		h := int(d.Hours())
+		if h == 1 {
+			return "1 hour ago"
+		}
+		return fmt.Sprintf("%d hours ago", h)
+	default:
+		days := int(d.Hours() / 24)
+		if days == 1 {
+			return "1 day ago"
+		}
+		return fmt.Sprintf("%d days ago", days)
+	}
 }

--- a/internal/http/templates/admin_builds.html
+++ b/internal/http/templates/admin_builds.html
@@ -1,7 +1,17 @@
 {{template "admin_layout" .}}
 {{define "title"}}Builds{{end}}
 {{define "content"}}
-<h1 class="text-xl font-bold mb-6">Build History</h1>
+<div class="flex items-center justify-between mb-6">
+<div>
+<h1 class="text-xl font-bold">Build History</h1>
+{{if .LastBuildStartedAt}}<p class="text-sm text-gray-500 mt-1">Last build: {{timeAgo .LastBuildStartedAt}}</p>{{end}}
+</div>
+<form method="POST" action="/admin/builds/trigger">
+<button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors">Run Build Now</button>
+</form>
+</div>
+{{if .Triggered}}<div class="mb-4 px-4 py-3 text-sm bg-blue-50 text-blue-700 rounded-lg border border-blue-200">Pipeline triggered. It may take a few minutes to complete.</div>{{end}}
+{{if .Error}}<div class="mb-4 px-4 py-3 text-sm bg-red-50 text-red-700 rounded-lg border border-red-200">{{.Error}}</div>{{end}}
 {{if not .Builds}}
 <p class="text-gray-500">No builds found.</p>
 {{else}}
@@ -22,7 +32,7 @@
 {{range .Builds}}
 <tr class="border-t border-gray-100 hover:bg-gray-50">
 <td class="px-4 py-2 font-mono text-xs">{{.ID}}</td>
-<td class="px-4 py-2 text-xs text-gray-500">{{.StartedAt}}</td>
+<td class="px-4 py-2 text-xs text-gray-500" title="{{.StartedAt}}">{{formatCST .StartedAt}}</td>
 <td class="px-4 py-2 text-right">{{.PackagesTotal}}</td>
 <td class="px-4 py-2 text-right">{{.PackagesChanged}}</td>
 <td class="px-4 py-2 text-right">{{.ArtifactCount}}</td>


### PR DESCRIPTION
## Summary
- Add **"Run Build Now"** button on `/admin/builds` that triggers `wpcomposer pipeline` as a subprocess
- System-wide file lock (`storage/pipeline.lock`) prevents concurrent pipeline runs across all entry points (cron, CLI, HTTP trigger)
- HTTP handler acquires the lock and passes the locked fd to the child process via `ExtraFiles` for atomic handoff with no TOCTOU gap
- Child validates inherited fd via inode identity check + flock ownership verification
- Show **"Last build: X ago"** relative time on builds page header
- Replace raw RFC3339 timestamps with human-readable CST times (raw value preserved in tooltip)
- Flash messages for trigger success and error states (including "build already running")

## Test plan
- [ ] Verify "Run Build Now" triggers a pipeline and redirects with success flash
- [ ] Verify clicking trigger while a pipeline is running shows "build already running" error
- [ ] Verify `wpcomposer pipeline` CLI still acquires lock and blocks concurrent runs
- [ ] Verify timestamps display in CST with raw RFC3339 in tooltip
- [ ] Verify "Last build: X ago" shows correct relative time
- [ ] Run `go test ./cmd/wpcomposer/cmd/ -run TestAcquireLock -v` — 4 lock tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)