### PR TITLE
Add air live-reload for local development

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,6 @@
+[build]
+  cmd = "make build"
+  full_bin = "ADMIN_ALLOW_CIDR= ./wpcomposer dev --addr :8080"
+  exclude_dir = ["storage", "bin", "test", "docs", ".git"]
+  include_ext = ["go", "html", "css", "tmpl"]
+  kill_delay = "1s"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ storage/
 *.db-shm
 .env
 benchmarks/results/
+tmp/

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,9 @@ build: tailwind
 install:
 	go install ./cmd/wpcomposer
 
-# Build and start dev server (migrations, seed data, serve)
-dev: build
-	ADMIN_ALLOW_CIDR= ./wpcomposer dev --addr :8080
+# Live-reload dev server (migrations, seed data, serve)
+dev: tailwind-install
+	air
 
 # Run all tests
 test:

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,6 +3,8 @@
 ## Prerequisites
 
 - Go 1.26+
+- [air](https://github.com/air-verse/air) — `go install github.com/air-verse/air@latest`
+- [golangci-lint](https://github.com/golangci/golangci-lint) — `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest` (for `make lint`)
 
 ## Quick Start
 
@@ -87,7 +89,7 @@ Env-first with optional YAML config file (env overrides YAML).
 ## Make Targets
 
 ```bash
-make dev    # Build + bootstrap + serve
+make dev    # Build + bootstrap + serve (live-reload via air)
 make test   # Run all tests
 make build  # Build binary
 make clean  # Remove artifacts


### PR DESCRIPTION
## Summary
- `make dev` now uses [air](https://github.com/air-verse/air) for automatic rebuilds on file changes
- Added `.air.toml` config (rebuilds via `make build`, runs `wpcomposer dev`)
- Documented `air` and `golangci-lint` as prerequisites in dev docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)