### PR TITLE
Fix dev-trunk regression and accept v-prefixed versions

### DIFF
--- a/internal/version/normalize.go
+++ b/internal/version/normalize.go
@@ -20,7 +20,10 @@ func Normalize(v string) string {
 	if v == "" {
 		return ""
 	}
-	if strings.EqualFold(v, "trunk") {
+	// Strip leading v/V to match Composer's VersionParser behavior.
+	v = strings.TrimPrefix(v, "v")
+	v = strings.TrimPrefix(v, "V")
+	if strings.EqualFold(v, "trunk") || v == "dev-trunk" {
 		return "dev-trunk"
 	}
 	if !IsValid(v) {
@@ -35,7 +38,7 @@ func IsValid(v string) bool {
 	if v == "" {
 		return false
 	}
-	if strings.EqualFold(v, "trunk") {
+	if strings.EqualFold(v, "trunk") || v == "dev-trunk" {
 		return true
 	}
 	return validVersion.MatchString(v)

--- a/internal/version/normalize_test.go
+++ b/internal/version/normalize_test.go
@@ -17,6 +17,9 @@ func TestNormalize(t *testing.T) {
 		{"trunk", "dev-trunk"},
 		{"Trunk", "dev-trunk"},
 		{"TRUNK", "dev-trunk"},
+		{"dev-trunk", "dev-trunk"},
+		{"vtrunk", "dev-trunk"},
+		{"Vtrunk", "dev-trunk"},
 
 		// Valid pre-release suffixes
 		{"1.0-beta1", "1.0-beta1"},
@@ -48,8 +51,14 @@ func TestNormalize(t *testing.T) {
 		{"latest", ""},
 		{"not a version", ""},
 
+		// Leading v stripped (Composer VersionParser compatibility, issue #19)
+		{"v1.0", "1.0"},
+		{"v1.0.0", "1.0.0"},
+		{"V2.0.0", "2.0.0"},
+		{"v1.13.11-beta.0", "1.13.11-beta.0"},
+		{"v20100102", "20100102"},
+
 		// Invalid: structural
-		{"v1.0", ""},      // leading v
 		{"1.0.0.0.1", ""}, // 5+ parts
 
 		// Invalid: non-Composer pre-release suffixes (issue #17)
@@ -90,7 +99,7 @@ func TestNormalize(t *testing.T) {
 
 func TestIsValid(t *testing.T) {
 	valid := []string{
-		"1.0", "1.0.0", "1.0.0.0", "trunk",
+		"1.0", "1.0.0", "1.0.0.0", "trunk", "dev-trunk",
 		"1.0-beta1", "1.0-RC2", "1.0-alpha",
 		"1.0-dev", "1.0-dev.1", "1.0-stable",
 	}
@@ -101,7 +110,7 @@ func TestIsValid(t *testing.T) {
 	}
 
 	invalid := []string{
-		"", "stable", "1.0.0.0.1", "not valid", "v1.0",
+		"", "stable", "1.0.0.0.1", "not valid",
 		"3.1.0-dev1", "3.1.0-dev2", "3.1.0-free",
 		"1.0f", "1.0-foo",
 		"1.0-beta.", "1.0-rc.", "1.0-alpha.", "1.0-dev.", "1.0-stable.",
@@ -117,21 +126,25 @@ func TestNormalizeVersions(t *testing.T) {
 	input := map[string]string{
 		"1.0":        "https://example.com/1.0.zip",
 		"2.0":        "https://example.com/2.0.zip",
-		"trunk":      "https://example.com/trunk.zip",
+		"dev-trunk":  "https://example.com/trunk.zip",
+		"v3.0":       "https://example.com/v3.0.zip",
 		"":           "https://example.com/empty.zip",
 		"bad!":       "https://example.com/bad.zip",
 		"3.1.0-dev1": "https://example.com/dev1.zip",
 	}
 
 	got := NormalizeVersions(input)
-	if len(got) != 3 {
-		t.Fatalf("NormalizeVersions returned %d entries, want 3", len(got))
+	if len(got) != 4 {
+		t.Fatalf("NormalizeVersions returned %d entries, want 4", len(got))
 	}
 	if got["1.0"] != "https://example.com/1.0.zip" {
 		t.Error("missing 1.0")
 	}
 	if got["dev-trunk"] != "https://example.com/trunk.zip" {
 		t.Error("missing dev-trunk")
+	}
+	if got["3.0"] != "https://example.com/v3.0.zip" {
+		t.Error("v3.0 should have been normalized to 3.0")
 	}
 	if _, ok := got["3.1.0-dev1"]; ok {
 		t.Error("3.1.0-dev1 should have been filtered out")


### PR DESCRIPTION
## Summary

- Recognize `dev-trunk` as a valid passthrough in `Normalize()` and `IsValid()`,
  fixing a regression from #18 where the builder's defense-in-depth filter
  stripped dev-trunk from every package's metadata.
- Strip leading `v`/`V` prefix instead of rejecting, matching Composer's
  `VersionParser` behavior (e.g. `v1.0.0` normalizes to `1.0.0`).
- Move v-stripping before trunk canonicalization to prevent `vtrunk` from
  leaking as a raw version string.

Closes #19

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint` clean
- [ ] After deploy: verify `dev-trunk` is restored in
  `https://repo.wp-composer.com/p2/wp-plugin/elementor.json`
- [ ] Verify v-prefixed versions from wp.org are now included with v stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)