### PR TITLE
Drop WordPress Core Installer reference for standard installation

### DIFF
--- a/internal/http/templates/roots_wordpress.html
+++ b/internal/http/templates/roots_wordpress.html
@@ -75,8 +75,6 @@
 </button>
 </div>
 
-<p class="text-gray-600 mb-4 leading-relaxed">A WordPress Core Installer package is required to handle the installation path. We provide <a href="https://github.com/roots/wordpress-core-installer" class="text-brand-primary hover:underline" rel="noopener">roots/wordpress-core-installer</a> for this.</p>
-
 <h2 class="text-2xl font-bold text-gray-900 mb-4">Example configurations</h2>
 
 <h3 class="text-lg font-semibold text-gray-900 mb-3">Standard (recommended)</h3>
@@ -95,7 +93,6 @@
   <span class="text-green-700">"require"</span>: {
     <span class="text-green-700">"composer/installers"</span>: <span class="text-green-700">"^2.2"</span>,
     <span class="text-green-700">"roots/wordpress"</span>: <span class="text-green-700">"^6.8"</span>,
-    <span class="text-green-700">"roots/wordpress-core-installer"</span>: <span class="text-green-700">"^1.0"</span>,
     <span class="text-green-700">"wp-plugin/woocommerce"</span>: <span class="text-green-700">"^10.0"</span>,
     <span class="text-green-700">"wp-theme/twentytwentyfive"</span>: <span class="text-green-700">"^1.0"</span>
   },
@@ -114,7 +111,7 @@
 <div class="bg-gray-50/50 px-4 py-2 text-xs text-gray-500 border-b border-gray-200/40">composer.json</div>
 <pre class="p-4 text-sm font-mono leading-relaxed overflow-x-auto"><code>{
   <span class="text-green-700">"require"</span>: {
-    <span class="text-green-700">"roots/wordpress-core-installer"</span>: <span class="text-green-700">"^1.0"</span>,
+    <span class="text-green-700">"roots/wordpress-core-installer"</span>: <span class="text-green-700">"^3.0"</span>,
     <span class="text-green-700">"roots/wordpress-full"</span>: <span class="text-green-700">"^6.8"</span>
   },
   <span class="text-green-700">"config"</span>: {


### PR DESCRIPTION
Removed the mention of the WordPress Core Installer package from the instructions to simplify them.
The core installer [is part of](https://github.com/roots/wordpress/blob/a538b8ba3f0e6d17528d5bf53bdea131f3f1773b/composer.json#L16) the `roots/wordpress` meta package.

Also, updated to version 3.0 in the composer.json example.

Edit: forgot to say congrats & thanks for the initiative; that's fantastic! 🚀