### PR TITLE
Show sunset warning to Composer v1 users

### DIFF
--- a/internal/repository/builder.go
+++ b/internal/repository/builder.go
@@ -270,6 +270,8 @@ func Build(ctx context.Context, db *sql.DB, opts BuildOpts) (*BuildResult, error
 		"providers-url":              "/p/%package%$%hash%.json",
 		"provider-includes":          providerIncludes,
 		"available-package-patterns": []string{"wp-plugin/*", "wp-theme/*"},
+		"warning":                    "Support for Composer 1 will be shut down in the near future. You should upgrade to Composer 2.",
+		"warning-versions":           "<1.999",
 	}
 
 	rootHash, rootData, err := HashJSON(packagesJSON)


### PR DESCRIPTION
Using `warning` and `warning-versions` instead of `warnings` for Composer v1 compatibility.

Related: https://github.com/roots/wp-composer/issues/24

Mimic https://packagist.org/packages.json response:

```json
{
    "warning":"Support for Composer 1 has been shutdown on September 1st 2025. You should upgrade to Composer 2. See https://blog.packagist.com/shutting-down-packagist-org-support-for-composer-1-x/",
    "warning-versions":"<1.999"
}
```