### PR TITLE
Server: Allow second `SIGINT` / `SIGTERM` to force exit

### DIFF
--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -50,12 +50,13 @@ func ListenAndServe(a *app.App) error {
 		close(errCh)
 	}()
 
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	select {
-	case sig := <-quit:
-		a.Logger.Info("shutting down", "signal", sig.String())
+	case <-sigCtx.Done():
+		a.Logger.Info("shutting down", "cause", context.Cause(sigCtx))
+		stop()
 	case err := <-errCh:
 		if err != nil {
 			sentry.CaptureException(err)


### PR DESCRIPTION
Before:

1. Boot the server
2. Press <kbd>Ctrl</kbd> + <kbd>C</kbd> once to trigger graceful shutdown
3. Press <kbd>Ctrl</kbd> + <kbd>C</kbd> again. This has no effect. You must wait for the server to shut down

After:

1. Boot the server
2. Press <kbd>Ctrl</kbd> + <kbd>C</kbd> once to trigger graceful shutdown
3. Press <kbd>Ctrl</kbd> + <kbd>C</kbd> again to force exit immediately