### PR TITLE
Skip Sentry reporting for context cancellation errors

### DIFF
--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -30,7 +30,12 @@ import (
 const perPage = 12
 
 // captureError reports a non-panic error to Sentry with the request's hub.
+// It silently ignores context cancellation errors (timeouts, client disconnects)
+// since these are expected during normal operation.
 func captureError(r *http.Request, err error) {
+	if r.Context().Err() != nil {
+		return
+	}
 	if hub := sentry.GetHubFromContext(r.Context()); hub != nil {
 		hub.CaptureException(err)
 	} else {


### PR DESCRIPTION
## Summary
- Centralize context cancellation check in `captureError` so timeouts and client disconnects are silently ignored instead of reported to Sentry
- Fixes false-positive alert from `WP-COMPOSER-4` (`context canceled` on `GET /`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)