### PR TITLE
Remove socket activation incompatible with Litestream

### DIFF
--- a/deploy/ansible/roles/wpcomposer/tasks/main.yml
+++ b/deploy/ansible/roles/wpcomposer/tasks/main.yml
@@ -7,13 +7,10 @@
     group: www-data
     mode: "0640"
 
-- name: Deploy wpcomposer socket
-  template:
-    src: wpcomposer.socket.j2
-    dest: /etc/systemd/system/wpcomposer.socket
-    owner: root
-    group: root
-    mode: "0644"
+- name: Remove legacy wpcomposer socket unit
+  file:
+    path: /etc/systemd/system/wpcomposer.socket
+    state: absent
   notify: Reload systemd
 
 - name: Deploy wpcomposer service
@@ -81,18 +78,6 @@
 
 - name: Flush handlers
   meta: flush_handlers
-
-- name: Stop wpcomposer service before socket activation
-  service:
-    name: wpcomposer
-    state: stopped
-  ignore_errors: yes
-
-- name: Enable and start wpcomposer socket
-  service:
-    name: wpcomposer.socket
-    state: started
-    enabled: yes
 
 - name: Enable and start wpcomposer service
   service:

--- a/deploy/ansible/roles/wpcomposer/templates/wpcomposer.service.j2
+++ b/deploy/ansible/roles/wpcomposer/templates/wpcomposer.service.j2
@@ -1,7 +1,6 @@
 [Unit]
 Description=WP Composer
 After=network.target
-Requires=wpcomposer.socket
 
 [Service]
 Type=simple

--- a/deploy/ansible/roles/wpcomposer/templates/wpcomposer.socket.j2
+++ b/deploy/ansible/roles/wpcomposer/templates/wpcomposer.socket.j2
@@ -1,9 +1,0 @@
-[Unit]
-Description=WP Composer Socket
-
-[Socket]
-ListenStream={{ go_listen_addr }}
-NoDelay=true
-
-[Install]
-WantedBy=sockets.target

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -29,23 +28,11 @@ func ListenAndServe(a *app.App) error {
 		IdleTimeout:  60 * time.Second,
 	}
 
-	ln, err := socketActivationListener()
-	if err != nil {
-		return fmt.Errorf("socket activation: %w", err)
-	}
-
 	errCh := make(chan error, 1)
 	go func() {
-		if ln != nil {
-			a.Logger.Info("starting server (socket activated)", "addr", ln.Addr().String())
-			if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				errCh <- fmt.Errorf("server error: %w", err)
-			}
-		} else {
-			a.Logger.Info("starting server", "addr", a.Config.Server.Addr)
-			if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				errCh <- fmt.Errorf("server error: %w", err)
-			}
+		a.Logger.Info("starting server", "addr", a.Config.Server.Addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- fmt.Errorf("server error: %w", err)
 		}
 		close(errCh)
 	}()
@@ -77,26 +64,4 @@ func ListenAndServe(a *app.App) error {
 
 	a.Logger.Info("server stopped")
 	return nil
-}
-
-// socketActivationListener returns a net.Listener from a systemd-passed fd,
-// or nil if not running under socket activation.
-func socketActivationListener() (net.Listener, error) {
-	pid, ok := os.LookupEnv("LISTEN_PID")
-	if !ok || pid != fmt.Sprintf("%d", os.Getpid()) {
-		return nil, nil
-	}
-
-	// systemd passes sockets starting at fd 3
-	f := os.NewFile(3, "systemd-socket")
-	if f == nil {
-		return nil, nil
-	}
-	defer func() { _ = f.Close() }()
-
-	ln, err := net.FileListener(f)
-	if err != nil {
-		return nil, fmt.Errorf("creating listener from fd 3: %w", err)
-	}
-	return ln, nil
 }


### PR DESCRIPTION
## Summary
- Socket activation broke when Litestream was added as a wrapper in e759618 — `LISTEN_PID` points at Litestream, not the Go binary, so the PID check always failed and the app tried to bind `:8080` directly, conflicting with the socket unit already holding that port
- Removes the socket unit, `socketActivationListener()`, and `Requires=wpcomposer.socket` from the service
- Adds Ansible cleanup task to remove the socket unit file from existing servers

## Test plan
- [x] Verify `make test` passes
- [ ] Deploy and confirm service starts without crash loop
- [ ] Verify `/health` endpoint responds
- [ ] Confirm Sentry issue WP-COMPOSER-2 stops recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)