### PR TITLE
Remove `only` from usage instructions

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -39,8 +39,7 @@ jobs:
               {
                 "name": "wp-packages",
                 "type": "composer",
-                "url": "https://repo.wp-packages.org",
-                "only": ["wp-plugin/*", "wp-theme/*"]
+                "url": "https://repo.wp-packages.org"
               }
             ],
             "require": {

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Add the repository to your `composer.json`:
     {
       "name": "wp-packages",
       "type": "composer",
-      "url": "https://repo.wp-packages.org",
-      "only": ["wp-plugin/*", "wp-theme/*"]
+      "url": "https://repo.wp-packages.org"
     }
   ],
   "require": {
@@ -80,8 +79,7 @@ A typical [Bedrock](https://roots.io/bedrock/) project uses `roots/wordpress` fo
     {
       "name": "wp-packages",
       "type": "composer",
-      "url": "https://repo.wp-packages.org",
-      "only": ["wp-plugin/*", "wp-theme/*"]
+      "url": "https://repo.wp-packages.org"
     }
   ],
   "require": {

--- a/benchmarks/resolve.sh
+++ b/benchmarks/resolve.sh
@@ -47,15 +47,12 @@ generate_composer_json() {
   # Remove trailing comma+newline, add newline
   require="${require%,$'\n'}"
 
-  local only_pattern="${prefix}/*"
-
   cat <<EOF
 {
   "repositories": [
     {
       "type": "composer",
-      "url": "${repo_url}",
-      "only": ["${only_pattern}"]
+      "url": "${repo_url}"
     }
   ],
   "require": {

--- a/internal/http/templates/index.html
+++ b/internal/http/templates/index.html
@@ -108,8 +108,7 @@
     {
       <span class="text-green-700">"name"</span>: <span class="text-green-700">"wp-packages"</span>,
       <span class="text-green-700">"type"</span>: <span class="text-green-700">"composer"</span>,
-      <span class="text-green-700">"url"</span>: <span class="text-green-700">"https://repo.wp-packages.org"</span>,
-      <span class="text-green-700">"only"</span>: [<span class="text-green-700">"wp-plugin/*"</span>, <span class="text-green-700">"wp-theme/*"</span>]
+      <span class="text-green-700">"url"</span>: <span class="text-green-700">"https://repo.wp-packages.org"</span>
     }
   ],
   <span class="text-green-700">"require"</span>: {

--- a/internal/http/templates/roots_wordpress.html
+++ b/internal/http/templates/roots_wordpress.html
@@ -86,8 +86,7 @@
     {
       <span class="text-green-700">"name"</span>: <span class="text-green-700">"wp-packages"</span>,
       <span class="text-green-700">"type"</span>: <span class="text-green-700">"composer"</span>,
-      <span class="text-green-700">"url"</span>: <span class="text-green-700">"https://repo.wp-packages.org"</span>,
-      <span class="text-green-700">"only"</span>: [<span class="text-green-700">"wp-plugin/*"</span>, <span class="text-green-700">"wp-theme/*"</span>]
+      <span class="text-green-700">"url"</span>: <span class="text-green-700">"https://repo.wp-packages.org"</span>
     }
   ],
   <span class="text-green-700">"require"</span>: {

--- a/scripts/migrate-from-wpackagist.sh
+++ b/scripts/migrate-from-wpackagist.sh
@@ -88,8 +88,7 @@ jq --indent "$INDENT" '
     {
       "name": "wp-packages",
       "type": "composer",
-      "url": "https://repo.wp-packages.org",
-      "only": ["wp-plugin/*", "wp-theme/*"]
+      "url": "https://repo.wp-packages.org"
     };
 
   # Replace wpackagist repository with wp-packages (handles both array and object formats)


### PR DESCRIPTION
Composer v2 reads `available-package-patterns` from repo's `/packages.json`.