### PR TITLE
Move OG image generation from request handler to pipeline

### DIFF
--- a/cmd/wppackages/cmd/pipeline.go
+++ b/cmd/wppackages/cmd/pipeline.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/roots/wp-packages/internal/deploy"
+	"github.com/roots/wp-packages/internal/og"
 	"github.com/spf13/cobra"
 )
 
@@ -170,10 +171,20 @@ func executePipelineSteps(cmd *cobra.Command, ctx context.Context, skipDiscover,
 	pipelineStepDurations.Build = intPtr(int(time.Since(stepStart).Seconds()))
 
 	if !skipDeploy {
+		application.Logger.Info("pipeline: generating OG images for new packages")
+		ogUploader := og.NewUploader(application.Config.R2)
+		ogResult, err := og.GenerateNew(ctx, application.DB, ogUploader, nil, application.Logger)
+		if err != nil {
+			application.Logger.Warn("pipeline: OG generation failed", "error", err)
+		} else if ogResult.Generated > 0 || ogResult.Errors > 0 {
+			application.Logger.Info("pipeline: OG generation done",
+				"generated", ogResult.Generated, "errors", ogResult.Errors)
+		}
+
 		application.Logger.Info("pipeline: running deploy")
 		deployCmd.SetContext(ctx)
 		stepStart = time.Now()
-		err := runDeploy(deployCmd, nil)
+		err = runDeploy(deployCmd, nil)
 		pipelineStepDurations.Deploy = intPtr(int(time.Since(stepStart).Seconds()))
 		pipelineStepDurations.R2Upload = deployR2SyncSeconds
 		if err != nil {

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -29,10 +29,6 @@ import (
 
 const perPage = 12
 
-// ogSem limits concurrent OG image generation to avoid starving the pipeline
-// of DB write access under heavy crawler traffic.
-var ogSem = make(chan struct{}, 2)
-
 // captureError reports a non-panic error to Sentry with the request's hub.
 // It silently ignores context cancellation errors (timeouts, client disconnects)
 // since these are expected during normal operation.
@@ -226,17 +222,6 @@ func handleDetail(a *app.App, tmpl *templateSet) http.HandlerFunc {
 		versions := parseVersions(pkg)
 
 		ogKey := "social/" + pkg.Type + "/" + pkg.Name + ".png"
-		if pkg.OGImageGeneratedAt == nil {
-			// Generate on demand in background (skip if at capacity)
-			select {
-			case ogSem <- struct{}{}:
-				go func() {
-					defer func() { <-ogSem }()
-					generatePackageOG(a, pkg)
-				}()
-			default:
-			}
-		}
 
 		displayName := pkg.Name
 		if pkg.DisplayName != "" {
@@ -683,37 +668,6 @@ func ensureLocalFallbackOG(cfg *config.Config) {
 	}
 }
 
-// generatePackageOG generates an OG image for a package and saves it.
-func generatePackageOG(a *app.App, pkg *packageDetail) {
-	data := og.PackageData{
-		DisplayName:        pkg.DisplayName,
-		Name:               pkg.Name,
-		Type:               pkg.Type,
-		CurrentVersion:     pkg.CurrentVersion,
-		Description:        pkg.Description,
-		ActiveInstalls:     og.FormatInstalls(pkg.ActiveInstalls),
-		WpPackagesInstalls: og.FormatInstalls(pkg.WpPackagesInstallsTotal),
-	}
-
-	pngBytes, err := og.GeneratePackageImage(data)
-	if err != nil {
-		a.Logger.Error("generating OG image", "package", pkg.Name, "error", err)
-		sentry.CaptureException(err)
-		return
-	}
-
-	uploader := og.NewUploader(a.Config.R2)
-	key := "social/" + pkg.Type + "/" + pkg.Name + ".png"
-	if err := uploader.Upload(context.Background(), key, pngBytes); err != nil {
-		a.Logger.Error("uploading OG image", "package", pkg.Name, "error", err)
-		sentry.CaptureException(err)
-		return
-	}
-
-	_ = og.MarkOGGeneratedBySlug(context.Background(), a.DB, pkg.Type, pkg.Name, pkg.ActiveInstalls, pkg.WpPackagesInstallsTotal)
-	a.Logger.Info("generated OG image", "package", pkg.Type+"/"+pkg.Name)
-}
-
 // Query helpers
 
 type indexStats struct {
@@ -809,9 +763,8 @@ func queryPackages(ctx context.Context, db *sql.DB, f publicFilters, page, limit
 
 type packageDetail struct {
 	packageRow
-	VersionsJSON       string
-	OGImageGeneratedAt *string
-	UpdatedAt          string
+	VersionsJSON string
+	UpdatedAt    string
 }
 
 func packageExistsInactive(ctx context.Context, db *sql.DB, pkgType, name string) bool {
@@ -825,12 +778,12 @@ func queryPackageDetail(ctx context.Context, db *sql.DB, pkgType, name string) (
 	var p packageDetail
 	err := db.QueryRowContext(ctx, `SELECT type, name, COALESCE(display_name,''), COALESCE(description,''),
 		COALESCE(author,''), COALESCE(homepage,''), COALESCE(current_version,''),
-		downloads, active_installs, wp_packages_installs_total, versions_json, og_image_generated_at,
+		downloads, active_installs, wp_packages_installs_total, versions_json,
 		COALESCE(updated_at,'')
 		FROM packages WHERE type = ? AND name = ? AND is_active = 1`, pkgType, name,
 	).Scan(&p.Type, &p.Name, &p.DisplayName, &p.Description, &p.Author, &p.Homepage,
 		&p.CurrentVersion, &p.Downloads, &p.ActiveInstalls, &p.WpPackagesInstallsTotal,
-		&p.VersionsJSON, &p.OGImageGeneratedAt, &p.UpdatedAt)
+		&p.VersionsJSON, &p.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/og/generate.go
+++ b/internal/og/generate.go
@@ -43,10 +43,10 @@ func FormatInstalls(n int64) string {
 	return fmt.Sprintf("%d", n)
 }
 
-// GetPackagesNeedingOG returns packages that need OG image generation:
+// getPackagesNeedingOG returns packages that need OG image generation:
 // - Never generated (og_image_generated_at IS NULL)
 // - Install counts changed since last generation
-func GetPackagesNeedingOG(ctx context.Context, db *sql.DB, limit int) ([]PackageOGRow, error) {
+func getPackagesNeedingOG(ctx context.Context, db *sql.DB, limit int) ([]PackageOGRow, error) {
 	q := `SELECT id, type, name, COALESCE(display_name, ''), COALESCE(description, ''),
 		COALESCE(current_version, ''), active_installs, wp_packages_installs_total,
 		og_image_generated_at, og_image_installs, og_image_wp_installs
@@ -80,7 +80,7 @@ func GetPackagesNeedingOG(ctx context.Context, db *sql.DB, limit int) ([]Package
 }
 
 // MarkOGGenerated updates the OG tracking columns after successful generation.
-func MarkOGGenerated(ctx context.Context, db *sql.DB, id, activeInstalls, wpInstalls int64) error {
+func markOGGenerated(ctx context.Context, db *sql.DB, id, activeInstalls, wpInstalls int64) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	_, err := db.ExecContext(ctx, `UPDATE packages SET
 		og_image_generated_at = ?,
@@ -93,20 +93,6 @@ func MarkOGGenerated(ctx context.Context, db *sql.DB, id, activeInstalls, wpInst
 	return nil
 }
 
-// MarkOGGeneratedBySlug updates OG tracking columns by type+name.
-func MarkOGGeneratedBySlug(ctx context.Context, db *sql.DB, pkgType, name string, activeInstalls, wpInstalls int64) error {
-	now := time.Now().UTC().Format(time.RFC3339)
-	_, err := db.ExecContext(ctx, `UPDATE packages SET
-		og_image_generated_at = ?,
-		og_image_installs = ?,
-		og_image_wp_installs = ?
-		WHERE type = ? AND name = ?`, now, activeInstalls, wpInstalls, pkgType, name)
-	if err != nil {
-		return fmt.Errorf("marking OG generated for %s/%s: %w", pkgType, name, err)
-	}
-	return nil
-}
-
 // GenerateResult holds the outcome of a generation run.
 type GenerateResult struct {
 	Generated int
@@ -114,9 +100,98 @@ type GenerateResult struct {
 	Errors    int
 }
 
+// ImageRenderer generates a PNG for the given package data.
+type ImageRenderer func(PackageData) ([]byte, error)
+
+// GenerateNew generates OG images for packages that have never had one.
+func GenerateNew(ctx context.Context, db *sql.DB, uploader *Uploader, render ImageRenderer, logger *slog.Logger) (GenerateResult, error) {
+	if render == nil {
+		render = GeneratePackageImage
+	}
+
+	q := `SELECT id, type, name, COALESCE(display_name, ''), COALESCE(description, ''),
+		COALESCE(current_version, ''), active_installs, wp_packages_installs_total
+		FROM packages
+		WHERE is_active = 1 AND og_image_generated_at IS NULL
+		ORDER BY active_installs DESC`
+
+	rows, err := db.QueryContext(ctx, q)
+	if err != nil {
+		return GenerateResult{}, fmt.Errorf("querying new packages for OG: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	type newPkg struct {
+		id, installs, wpInstalls                         int64
+		pkgType, name, displayName, description, version string
+	}
+
+	var pkgs []newPkg
+	for rows.Next() {
+		var p newPkg
+		if err := rows.Scan(&p.id, &p.pkgType, &p.name, &p.displayName, &p.description, &p.version, &p.installs, &p.wpInstalls); err != nil {
+			return GenerateResult{}, fmt.Errorf("scanning OG row: %w", err)
+		}
+		pkgs = append(pkgs, p)
+	}
+	if err := rows.Err(); err != nil {
+		return GenerateResult{}, err
+	}
+
+	var result GenerateResult
+	for _, pkg := range pkgs {
+		if ctx.Err() != nil {
+			return result, ctx.Err()
+		}
+
+		data := PackageData{
+			DisplayName:        pkg.displayName,
+			Name:               pkg.name,
+			Type:               pkg.pkgType,
+			CurrentVersion:     pkg.version,
+			Description:        pkg.description,
+			ActiveInstalls:     FormatInstalls(pkg.installs),
+			WpPackagesInstalls: FormatInstalls(pkg.wpInstalls),
+		}
+
+		if err := generateAndUpload(ctx, render, uploader, db, pkg.id, pkg.pkgType, pkg.name, data, pkg.installs, pkg.wpInstalls, logger); err != nil {
+			result.Errors++
+			continue
+		}
+
+		result.Generated++
+		if result.Generated%100 == 0 {
+			logger.Info("OG generation progress", "generated", result.Generated)
+		}
+	}
+
+	return result, nil
+}
+
+func generateAndUpload(ctx context.Context, render ImageRenderer, uploader *Uploader, db *sql.DB, id int64, pkgType, name string, data PackageData, installs, wpInstalls int64, logger *slog.Logger) error {
+	pngBytes, err := render(data)
+	if err != nil {
+		logger.Error("generating OG image", "package", name, "error", err)
+		return err
+	}
+
+	key := fmt.Sprintf("social/%s/%s.png", pkgType, name)
+	if err := uploader.Upload(ctx, key, pngBytes); err != nil {
+		logger.Error("uploading OG image", "package", name, "error", err)
+		return err
+	}
+
+	if err := markOGGenerated(ctx, db, id, installs, wpInstalls); err != nil {
+		logger.Error("marking OG generated", "package", name, "error", err)
+		return err
+	}
+
+	return nil
+}
+
 // GenerateAll generates OG images for all packages that need them.
 func GenerateAll(ctx context.Context, db *sql.DB, uploader *Uploader, limit int, logger *slog.Logger) (GenerateResult, error) {
-	pkgs, err := GetPackagesNeedingOG(ctx, db, limit)
+	pkgs, err := getPackagesNeedingOG(ctx, db, limit)
 	if err != nil {
 		return GenerateResult{}, err
 	}
@@ -166,7 +241,7 @@ func GenerateAll(ctx context.Context, db *sql.DB, uploader *Uploader, limit int,
 			continue
 		}
 
-		if err := MarkOGGenerated(ctx, db, pkg.ID, pkg.ActiveInstalls, pkg.WpPackagesInstallsTotal); err != nil {
+		if err := markOGGenerated(ctx, db, pkg.ID, pkg.ActiveInstalls, pkg.WpPackagesInstallsTotal); err != nil {
 			logger.Error("marking OG generated", "package", pkg.Name, "error", err)
 			result.Errors++
 			continue

--- a/internal/og/generate_test.go
+++ b/internal/og/generate_test.go
@@ -1,0 +1,134 @@
+package og
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/roots/wp-packages/internal/db"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func stubRenderer(_ PackageData) ([]byte, error) {
+	return []byte("fake-png"), nil
+}
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("opening test db: %v", err)
+	}
+
+	_, err = database.Exec(`
+		CREATE TABLE packages (
+			id INTEGER PRIMARY KEY,
+			type TEXT NOT NULL CHECK(type IN ('plugin','theme')),
+			name TEXT NOT NULL,
+			display_name TEXT,
+			description TEXT,
+			current_version TEXT,
+			active_installs INTEGER NOT NULL DEFAULT 0,
+			wp_packages_installs_total INTEGER NOT NULL DEFAULT 0,
+			is_active INTEGER NOT NULL DEFAULT 1,
+			og_image_generated_at TEXT,
+			og_image_installs INTEGER NOT NULL DEFAULT 0,
+			og_image_wp_installs INTEGER NOT NULL DEFAULT 0,
+			UNIQUE(type, name)
+		)`)
+	if err != nil {
+		t.Fatalf("creating tables: %v", err)
+	}
+
+	t.Cleanup(func() { _ = database.Close() })
+	return database
+}
+
+func insertPackage(t *testing.T, database *sql.DB, pkgType, name, displayName, description, version string, installs, wpInstalls int64) {
+	t.Helper()
+	_, err := database.Exec(`INSERT INTO packages (type, name, display_name, description, current_version, active_installs, wp_packages_installs_total)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`, pkgType, name, displayName, description, version, installs, wpInstalls)
+	if err != nil {
+		t.Fatalf("inserting package: %v", err)
+	}
+}
+
+func markGenerated(t *testing.T, database *sql.DB, name string, installs, wpInstalls int64) {
+	t.Helper()
+	_, err := database.Exec(`UPDATE packages SET og_image_generated_at = '2026-01-01T00:00:00Z', og_image_installs = ?, og_image_wp_installs = ? WHERE name = ?`,
+		installs, wpInstalls, name)
+	if err != nil {
+		t.Fatalf("marking generated: %v", err)
+	}
+}
+
+func TestGenerateNew_GeneratesForNewPackages(t *testing.T) {
+	database := setupTestDB(t)
+	ctx := context.Background()
+	uploader := &Uploader{localDir: t.TempDir()}
+
+	insertPackage(t, database, "plugin", "akismet", "Akismet", "Anti-spam plugin", "6.0.0", 5000000, 100)
+	insertPackage(t, database, "plugin", "woocommerce", "WooCommerce", "eCommerce plugin", "9.6.2", 5000000, 200)
+
+	result, err := GenerateNew(ctx, database, uploader, stubRenderer, testLogger())
+	if err != nil {
+		t.Fatalf("GenerateNew: %v", err)
+	}
+
+	if result.Generated != 2 {
+		t.Errorf("expected 2 generated, got %d", result.Generated)
+	}
+
+	var genAt *string
+	err = database.QueryRow(`SELECT og_image_generated_at FROM packages WHERE name = 'akismet'`).Scan(&genAt)
+	if err != nil {
+		t.Fatalf("querying og_image_generated_at: %v", err)
+	}
+	if genAt == nil {
+		t.Error("expected og_image_generated_at to be set")
+	}
+}
+
+func TestGenerateNew_SkipsAlreadyGenerated(t *testing.T) {
+	database := setupTestDB(t)
+	ctx := context.Background()
+	uploader := &Uploader{localDir: t.TempDir()}
+
+	insertPackage(t, database, "plugin", "akismet", "Akismet", "Anti-spam plugin", "6.0.0", 5000000, 100)
+	markGenerated(t, database, "akismet", 5000000, 100)
+
+	insertPackage(t, database, "plugin", "woocommerce", "WooCommerce", "eCommerce plugin", "9.6.2", 5000000, 200)
+
+	result, err := GenerateNew(ctx, database, uploader, stubRenderer, testLogger())
+	if err != nil {
+		t.Fatalf("GenerateNew: %v", err)
+	}
+
+	if result.Generated != 1 {
+		t.Errorf("expected 1 generated (woocommerce only), got %d", result.Generated)
+	}
+}
+
+func TestGenerateNew_NothingToDo(t *testing.T) {
+	database := setupTestDB(t)
+	ctx := context.Background()
+	uploader := &Uploader{localDir: t.TempDir()}
+
+	insertPackage(t, database, "plugin", "akismet", "Akismet", "Anti-spam plugin", "6.0.0", 5000000, 100)
+	markGenerated(t, database, "akismet", 5000000, 100)
+
+	result, err := GenerateNew(ctx, database, uploader, stubRenderer, testLogger())
+	if err != nil {
+		t.Fatalf("GenerateNew: %v", err)
+	}
+
+	if result.Generated != 0 {
+		t.Errorf("expected 0 generated, got %d", result.Generated)
+	}
+}


### PR DESCRIPTION
Remove on-demand OG generation from the HTTP handler to eliminate SQLite write contention under crawler traffic. New packages get their OG images generated during the pipeline run (after build, before deploy). The daily batch job continues to handle regeneration when install counts change.

- Remove OG image generation from handler entirely
- Add GenerateNew() for first-time OG generation only
- Add ImageRenderer function type for testability
- Fix SQLite deadlock: collect rows before writing (open cursor + write)
- Remove unused MarkOGGeneratedBySlug