### PR TITLE
Fix OG image generation and simplify pipeline

### DIFF
--- a/cmd/wppackages/cmd/generate_og.go
+++ b/cmd/wppackages/cmd/generate_og.go
@@ -5,15 +5,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var generateOGLimit int
-
 var generateOGCmd = &cobra.Command{
 	Use:   "generate-og",
 	Short: "Generate OG images for packages that need them",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		uploader := og.NewUploader(application.Config.R2)
 
-		result, err := og.GenerateAll(cmd.Context(), application.DB, uploader, generateOGLimit, application.Logger)
+		result, err := og.GenerateAll(cmd.Context(), application.DB, uploader, application.Logger)
 		if err != nil {
 			return err
 		}
@@ -29,6 +27,5 @@ var generateOGCmd = &cobra.Command{
 
 func init() {
 	appCommand(generateOGCmd)
-	generateOGCmd.Flags().IntVar(&generateOGLimit, "limit", 1000, "max packages to generate")
 	rootCmd.AddCommand(generateOGCmd)
 }

--- a/cmd/wppackages/cmd/pipeline.go
+++ b/cmd/wppackages/cmd/pipeline.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/roots/wp-packages/internal/deploy"
-	"github.com/roots/wp-packages/internal/og"
 	"github.com/spf13/cobra"
 )
 
@@ -171,24 +170,14 @@ func executePipelineSteps(cmd *cobra.Command, ctx context.Context, skipDiscover,
 	pipelineStepDurations.Build = intPtr(int(time.Since(stepStart).Seconds()))
 
 	if !skipDeploy {
-		application.Logger.Info("pipeline: generating OG images for new packages")
-		ogUploader := og.NewUploader(application.Config.R2)
-		ogResult, err := og.GenerateNew(ctx, application.DB, ogUploader, nil, application.Logger)
-		if err != nil {
-			application.Logger.Warn("pipeline: OG generation failed", "error", err)
-		} else if ogResult.Generated > 0 || ogResult.Errors > 0 {
-			application.Logger.Info("pipeline: OG generation done",
-				"generated", ogResult.Generated, "errors", ogResult.Errors)
-		}
-
 		application.Logger.Info("pipeline: running deploy")
 		deployCmd.SetContext(ctx)
 		stepStart = time.Now()
-		err = runDeploy(deployCmd, nil)
+		deployErr := runDeploy(deployCmd, nil)
 		pipelineStepDurations.Deploy = intPtr(int(time.Since(stepStart).Seconds()))
 		pipelineStepDurations.R2Upload = deployR2SyncSeconds
-		if err != nil {
-			return fmt.Errorf("deploy: %w", err)
+		if deployErr != nil {
+			return fmt.Errorf("deploy: %w", deployErr)
 		}
 
 		// Clean up old builds after a successful deploy.

--- a/internal/og/generate.go
+++ b/internal/og/generate.go
@@ -5,8 +5,12 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"sync"
+	"sync/atomic"
 	"time"
 )
+
+const uploadConcurrency = 20
 
 // PackageOGRow holds the data needed for OG image generation decisions.
 type PackageOGRow struct {
@@ -45,8 +49,8 @@ func FormatInstalls(n int64) string {
 
 // getPackagesNeedingOG returns packages that need OG image generation:
 // - Never generated (og_image_generated_at IS NULL)
-// - Install counts changed since last generation
-func getPackagesNeedingOG(ctx context.Context, db *sql.DB, limit int) ([]PackageOGRow, error) {
+// - Composer install count changed since last generation
+func getPackagesNeedingOG(ctx context.Context, db *sql.DB) ([]PackageOGRow, error) {
 	q := `SELECT id, type, name, COALESCE(display_name, ''), COALESCE(description, ''),
 		COALESCE(current_version, ''), active_installs, wp_packages_installs_total,
 		og_image_generated_at, og_image_installs, og_image_wp_installs
@@ -54,13 +58,11 @@ func getPackagesNeedingOG(ctx context.Context, db *sql.DB, limit int) ([]Package
 		WHERE is_active = 1
 		AND (
 			og_image_generated_at IS NULL
-			OR active_installs != og_image_installs
 			OR wp_packages_installs_total != og_image_wp_installs
 		)
-		ORDER BY active_installs DESC
-		LIMIT ?`
+		ORDER BY active_installs DESC`
 
-	rows, err := db.QueryContext(ctx, q, limit)
+	rows, err := db.QueryContext(ctx, q)
 	if err != nil {
 		return nil, fmt.Errorf("querying packages for OG: %w", err)
 	}
@@ -100,98 +102,10 @@ type GenerateResult struct {
 	Errors    int
 }
 
-// ImageRenderer generates a PNG for the given package data.
-type ImageRenderer func(PackageData) ([]byte, error)
-
-// GenerateNew generates OG images for packages that have never had one.
-func GenerateNew(ctx context.Context, db *sql.DB, uploader *Uploader, render ImageRenderer, logger *slog.Logger) (GenerateResult, error) {
-	if render == nil {
-		render = GeneratePackageImage
-	}
-
-	q := `SELECT id, type, name, COALESCE(display_name, ''), COALESCE(description, ''),
-		COALESCE(current_version, ''), active_installs, wp_packages_installs_total
-		FROM packages
-		WHERE is_active = 1 AND og_image_generated_at IS NULL
-		ORDER BY active_installs DESC`
-
-	rows, err := db.QueryContext(ctx, q)
-	if err != nil {
-		return GenerateResult{}, fmt.Errorf("querying new packages for OG: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	type newPkg struct {
-		id, installs, wpInstalls                         int64
-		pkgType, name, displayName, description, version string
-	}
-
-	var pkgs []newPkg
-	for rows.Next() {
-		var p newPkg
-		if err := rows.Scan(&p.id, &p.pkgType, &p.name, &p.displayName, &p.description, &p.version, &p.installs, &p.wpInstalls); err != nil {
-			return GenerateResult{}, fmt.Errorf("scanning OG row: %w", err)
-		}
-		pkgs = append(pkgs, p)
-	}
-	if err := rows.Err(); err != nil {
-		return GenerateResult{}, err
-	}
-
-	var result GenerateResult
-	for _, pkg := range pkgs {
-		if ctx.Err() != nil {
-			return result, ctx.Err()
-		}
-
-		data := PackageData{
-			DisplayName:        pkg.displayName,
-			Name:               pkg.name,
-			Type:               pkg.pkgType,
-			CurrentVersion:     pkg.version,
-			Description:        pkg.description,
-			ActiveInstalls:     FormatInstalls(pkg.installs),
-			WpPackagesInstalls: FormatInstalls(pkg.wpInstalls),
-		}
-
-		if err := generateAndUpload(ctx, render, uploader, db, pkg.id, pkg.pkgType, pkg.name, data, pkg.installs, pkg.wpInstalls, logger); err != nil {
-			result.Errors++
-			continue
-		}
-
-		result.Generated++
-		if result.Generated%100 == 0 {
-			logger.Info("OG generation progress", "generated", result.Generated)
-		}
-	}
-
-	return result, nil
-}
-
-func generateAndUpload(ctx context.Context, render ImageRenderer, uploader *Uploader, db *sql.DB, id int64, pkgType, name string, data PackageData, installs, wpInstalls int64, logger *slog.Logger) error {
-	pngBytes, err := render(data)
-	if err != nil {
-		logger.Error("generating OG image", "package", name, "error", err)
-		return err
-	}
-
-	key := fmt.Sprintf("social/%s/%s.png", pkgType, name)
-	if err := uploader.Upload(ctx, key, pngBytes); err != nil {
-		logger.Error("uploading OG image", "package", name, "error", err)
-		return err
-	}
-
-	if err := markOGGenerated(ctx, db, id, installs, wpInstalls); err != nil {
-		logger.Error("marking OG generated", "package", name, "error", err)
-		return err
-	}
-
-	return nil
-}
-
 // GenerateAll generates OG images for all packages that need them.
-func GenerateAll(ctx context.Context, db *sql.DB, uploader *Uploader, limit int, logger *slog.Logger) (GenerateResult, error) {
-	pkgs, err := getPackagesNeedingOG(ctx, db, limit)
+// Rendering and uploading run concurrently; DB writes stay serial.
+func GenerateAll(ctx context.Context, db *sql.DB, uploader *Uploader, logger *slog.Logger) (GenerateResult, error) {
+	pkgs, err := getPackagesNeedingOG(ctx, db)
 	if err != nil {
 		return GenerateResult{}, err
 	}
@@ -201,57 +115,100 @@ func GenerateAll(ctx context.Context, db *sql.DB, uploader *Uploader, limit int,
 		return GenerateResult{}, nil
 	}
 
-	logger.Info("generating OG images", "packages", len(pkgs))
-
-	var result GenerateResult
+	// Filter out packages whose formatted display values haven't changed.
+	var work []PackageOGRow
+	var skipped int
 	for _, pkg := range pkgs {
-		if ctx.Err() != nil {
-			return result, ctx.Err()
-		}
-
-		// Skip if the formatted display values haven't changed
 		if pkg.OGImageGeneratedAt != nil &&
-			FormatInstalls(pkg.ActiveInstalls) == FormatInstalls(pkg.OGImageInstalls) &&
 			FormatInstalls(pkg.WpPackagesInstallsTotal) == FormatInstalls(pkg.OGImageWpInstalls) {
-			result.Skipped++
+			skipped++
 			continue
 		}
-
-		data := PackageData{
-			DisplayName:        pkg.DisplayName,
-			Name:               pkg.Name,
-			Type:               pkg.Type,
-			CurrentVersion:     pkg.CurrentVersion,
-			Description:        pkg.Description,
-			ActiveInstalls:     FormatInstalls(pkg.ActiveInstalls),
-			WpPackagesInstalls: FormatInstalls(pkg.WpPackagesInstallsTotal),
-		}
-
-		pngBytes, err := GeneratePackageImage(data)
-		if err != nil {
-			logger.Error("generating OG image", "package", pkg.Name, "error", err)
-			result.Errors++
-			continue
-		}
-
-		key := fmt.Sprintf("social/%s/%s.png", pkg.Type, pkg.Name)
-		if err := uploader.Upload(ctx, key, pngBytes); err != nil {
-			logger.Error("uploading OG image", "package", pkg.Name, "error", err)
-			result.Errors++
-			continue
-		}
-
-		if err := markOGGenerated(ctx, db, pkg.ID, pkg.ActiveInstalls, pkg.WpPackagesInstallsTotal); err != nil {
-			logger.Error("marking OG generated", "package", pkg.Name, "error", err)
-			result.Errors++
-			continue
-		}
-
-		result.Generated++
-		if result.Generated%100 == 0 {
-			logger.Info("OG generation progress", "generated", result.Generated, "total", len(pkgs))
-		}
+		work = append(work, pkg)
 	}
 
-	return result, nil
+	logger.Info("generating OG images", "packages", len(work), "skipped", skipped)
+
+	if len(work) == 0 {
+		return GenerateResult{Skipped: skipped}, nil
+	}
+
+	type dbUpdate struct {
+		id, installs, wpInstalls int64
+	}
+
+	var generated, errCount atomic.Int64
+	ch := make(chan PackageOGRow)
+	updates := make(chan dbUpdate, uploadConcurrency*2)
+
+	// Render + upload concurrently.
+	var wg sync.WaitGroup
+	for range uploadConcurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for pkg := range ch {
+				data := PackageData{
+					DisplayName:        pkg.DisplayName,
+					Name:               pkg.Name,
+					Type:               pkg.Type,
+					CurrentVersion:     pkg.CurrentVersion,
+					Description:        pkg.Description,
+					ActiveInstalls:     FormatInstalls(pkg.ActiveInstalls),
+					WpPackagesInstalls: FormatInstalls(pkg.WpPackagesInstallsTotal),
+				}
+
+				pngBytes, err := GeneratePackageImage(data)
+				if err != nil {
+					logger.Error("generating OG image", "package", pkg.Name, "error", err)
+					errCount.Add(1)
+					continue
+				}
+
+				key := fmt.Sprintf("social/%s/%s.png", pkg.Type, pkg.Name)
+				if err := uploader.Upload(ctx, key, pngBytes); err != nil {
+					logger.Error("uploading OG image", "package", pkg.Name, "error", err)
+					errCount.Add(1)
+					continue
+				}
+
+				updates <- dbUpdate{pkg.ID, pkg.ActiveInstalls, pkg.WpPackagesInstallsTotal}
+
+				if n := generated.Add(1); n%500 == 0 {
+					logger.Info("OG generation progress", "generated", n, "total", len(work))
+				}
+			}
+		}()
+	}
+
+	// Serial DB writer to avoid SQLite contention.
+	var dbErrors atomic.Int64
+	var dbWg sync.WaitGroup
+	dbWg.Add(1)
+	go func() {
+		defer dbWg.Done()
+		for u := range updates {
+			if err := markOGGenerated(ctx, db, u.id, u.installs, u.wpInstalls); err != nil {
+				logger.Error("marking OG generated", "id", u.id, "error", err)
+				dbErrors.Add(1)
+			}
+		}
+	}()
+
+	for _, pkg := range work {
+		if ctx.Err() != nil {
+			break
+		}
+		ch <- pkg
+	}
+	close(ch)
+	wg.Wait()
+	close(updates)
+	dbWg.Wait()
+
+	return GenerateResult{
+		Generated: int(generated.Load()),
+		Skipped:   skipped,
+		Errors:    int(errCount.Load() + dbErrors.Load()),
+	}, nil
 }

--- a/internal/og/generate_test.go
+++ b/internal/og/generate_test.go
@@ -14,10 +14,6 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }
 
-func stubRenderer(_ PackageData) ([]byte, error) {
-	return []byte("fake-png"), nil
-}
-
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 
@@ -68,7 +64,7 @@ func markGenerated(t *testing.T, database *sql.DB, name string, installs, wpInst
 	}
 }
 
-func TestGenerateNew_GeneratesForNewPackages(t *testing.T) {
+func TestGenerateAll_GeneratesNewPackages(t *testing.T) {
 	database := setupTestDB(t)
 	ctx := context.Background()
 	uploader := &Uploader{localDir: t.TempDir()}
@@ -76,9 +72,9 @@ func TestGenerateNew_GeneratesForNewPackages(t *testing.T) {
 	insertPackage(t, database, "plugin", "akismet", "Akismet", "Anti-spam plugin", "6.0.0", 5000000, 100)
 	insertPackage(t, database, "plugin", "woocommerce", "WooCommerce", "eCommerce plugin", "9.6.2", 5000000, 200)
 
-	result, err := GenerateNew(ctx, database, uploader, stubRenderer, testLogger())
+	result, err := GenerateAll(ctx, database, uploader, testLogger())
 	if err != nil {
-		t.Fatalf("GenerateNew: %v", err)
+		t.Fatalf("GenerateAll: %v", err)
 	}
 
 	if result.Generated != 2 {
@@ -95,7 +91,7 @@ func TestGenerateNew_GeneratesForNewPackages(t *testing.T) {
 	}
 }
 
-func TestGenerateNew_SkipsAlreadyGenerated(t *testing.T) {
+func TestGenerateAll_SkipsUnchanged(t *testing.T) {
 	database := setupTestDB(t)
 	ctx := context.Background()
 	uploader := &Uploader{localDir: t.TempDir()}
@@ -103,29 +99,45 @@ func TestGenerateNew_SkipsAlreadyGenerated(t *testing.T) {
 	insertPackage(t, database, "plugin", "akismet", "Akismet", "Anti-spam plugin", "6.0.0", 5000000, 100)
 	markGenerated(t, database, "akismet", 5000000, 100)
 
-	insertPackage(t, database, "plugin", "woocommerce", "WooCommerce", "eCommerce plugin", "9.6.2", 5000000, 200)
-
-	result, err := GenerateNew(ctx, database, uploader, stubRenderer, testLogger())
+	result, err := GenerateAll(ctx, database, uploader, testLogger())
 	if err != nil {
-		t.Fatalf("GenerateNew: %v", err)
+		t.Fatalf("GenerateAll: %v", err)
 	}
 
-	if result.Generated != 1 {
-		t.Errorf("expected 1 generated (woocommerce only), got %d", result.Generated)
+	if result.Generated != 0 {
+		t.Errorf("expected 0 generated, got %d", result.Generated)
 	}
 }
 
-func TestGenerateNew_NothingToDo(t *testing.T) {
+func TestGenerateAll_RegeneratesOnComposerInstallChange(t *testing.T) {
+	database := setupTestDB(t)
+	ctx := context.Background()
+	uploader := &Uploader{localDir: t.TempDir()}
+
+	insertPackage(t, database, "plugin", "akismet", "Akismet", "Anti-spam plugin", "6.0.0", 5000000, 500)
+	markGenerated(t, database, "akismet", 5000000, 100) // composer installs differ
+
+	result, err := GenerateAll(ctx, database, uploader, testLogger())
+	if err != nil {
+		t.Fatalf("GenerateAll: %v", err)
+	}
+
+	if result.Generated != 1 {
+		t.Errorf("expected 1 generated, got %d", result.Generated)
+	}
+}
+
+func TestGenerateAll_IgnoresWPInstallChange(t *testing.T) {
 	database := setupTestDB(t)
 	ctx := context.Background()
 	uploader := &Uploader{localDir: t.TempDir()}
 
 	insertPackage(t, database, "plugin", "akismet", "Akismet", "Anti-spam plugin", "6.0.0", 5000000, 100)
-	markGenerated(t, database, "akismet", 5000000, 100)
+	markGenerated(t, database, "akismet", 4000000, 100) // WP installs differ, composer same
 
-	result, err := GenerateNew(ctx, database, uploader, stubRenderer, testLogger())
+	result, err := GenerateAll(ctx, database, uploader, testLogger())
 	if err != nil {
-		t.Fatalf("GenerateNew: %v", err)
+		t.Fatalf("GenerateAll: %v", err)
 	}
 
 	if result.Generated != 0 {


### PR DESCRIPTION
## Summary
- Remove OG image generation from the pipeline — the 3 AM systemd timer handles all generation
- Remove the `--limit` flag from `generate-og` so the nightly job processes all packages that need updates
- Add concurrency (20 goroutines) to `generate-og` for render + upload (DB writes stay serial)
- Only regenerate images when Composer install counts change (ignore WP.org install count changes)

## Test plan
- [x] Deploy and run `wppackages generate-og` to backfill all 61k images to R2
- [x] Verify images are accessible on CDN after generation
- [ ] Confirm nightly timer still runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)