### PR TITLE
Fix stale versions from last_committed rollback during upsert

### DIFF
--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -98,8 +98,12 @@ func UpsertPackage(ctx context.Context, db *sql.DB, pkg *Package) error {
 			rating = excluded.rating,
 			num_ratings = excluded.num_ratings,
 			is_active = excluded.is_active,
-			last_committed = excluded.last_committed,
-			last_synced_at = excluded.last_synced_at,
+			last_committed = CASE
+				WHEN excluded.last_committed > COALESCE(packages.last_committed, '')
+				THEN excluded.last_committed
+				ELSE packages.last_committed
+			END,
+			last_synced_at = COALESCE(excluded.last_synced_at, packages.last_synced_at),
 			last_sync_run_id = COALESCE(excluded.last_sync_run_id, packages.last_sync_run_id),
 			updated_at = excluded.updated_at`,
 		pkg.Type, pkg.Name, pkg.DisplayName, pkg.Description, pkg.Author,
@@ -212,8 +216,12 @@ func BatchUpsertPackages(ctx context.Context, db *sql.DB, pkgs []*Package) error
 			rating = excluded.rating,
 			num_ratings = excluded.num_ratings,
 			is_active = excluded.is_active,
-			last_committed = excluded.last_committed,
-			last_synced_at = excluded.last_synced_at,
+			last_committed = CASE
+				WHEN excluded.last_committed > COALESCE(packages.last_committed, '')
+				THEN excluded.last_committed
+				ELSE packages.last_committed
+			END,
+			last_synced_at = COALESCE(excluded.last_synced_at, packages.last_synced_at),
 			last_sync_run_id = COALESCE(excluded.last_sync_run_id, packages.last_sync_run_id),
 			updated_at = excluded.updated_at`)
 	if err != nil {
@@ -272,9 +280,9 @@ func GetPackagesNeedingUpdate(ctx context.Context, db *sql.DB, opts UpdateQueryO
 
 	if !opts.Force && opts.Name == "" {
 		if opts.IncludeInactive {
-			query += ` AND (last_synced_at IS NULL OR last_committed > last_synced_at OR (is_active = 0 AND (last_synced_at IS NULL OR last_synced_at < datetime('now', '-30 days'))))`
+			query += ` AND (last_synced_at IS NULL OR last_committed > last_synced_at OR last_synced_at < datetime('now', '-7 days') OR (is_active = 0 AND (last_synced_at IS NULL OR last_synced_at < datetime('now', '-30 days'))))`
 		} else {
-			query += ` AND is_active = 1 AND (last_synced_at IS NULL OR last_committed > last_synced_at)`
+			query += ` AND is_active = 1 AND (last_synced_at IS NULL OR last_committed > last_synced_at OR last_synced_at < datetime('now', '-7 days'))`
 		}
 	} else if !opts.IncludeInactive && opts.Name == "" {
 		query += ` AND is_active = 1`

--- a/internal/packages/package_test.go
+++ b/internal/packages/package_test.go
@@ -271,8 +271,8 @@ func TestGetPackagesNeedingUpdate(t *testing.T) {
 	lc := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	_ = UpsertShellPackage(ctx, database, "plugin", "needs-update", &lc)
 
-	// Package already synced with matching date — does not need update
-	synced := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	// Package already synced recently — does not need update
+	synced := time.Now().UTC()
 	pkg := &Package{
 		Type:          "plugin",
 		Name:          "up-to-date",
@@ -292,6 +292,33 @@ func TestGetPackagesNeedingUpdate(t *testing.T) {
 	}
 	if pkgs[0].Name != "needs-update" {
 		t.Errorf("got name=%s, want needs-update", pkgs[0].Name)
+	}
+
+	// Package synced more than 7 days ago — should be picked up for periodic resync
+	staleSync := time.Now().UTC().AddDate(0, 0, -8)
+	stalePkg := &Package{
+		Type:          "plugin",
+		Name:          "stale-sync",
+		VersionsJSON:  "{}",
+		IsActive:      true,
+		LastCommitted: &lc,
+		LastSyncedAt:  &staleSync,
+	}
+	_ = UpsertPackage(ctx, database, stalePkg)
+
+	pkgs, err = GetPackagesNeedingUpdate(ctx, database, UpdateQueryOpts{Type: "plugin"})
+	if err != nil {
+		t.Fatalf("query after stale insert: %v", err)
+	}
+	found := false
+	for _, p := range pkgs {
+		if p.Name == "stale-sync" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected stale-sync to be included in packages needing update (7-day resync)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `UpsertPackage` and `BatchUpsertPackages` unconditionally overwrote
  `last_committed` with the API's older `last_updated` date, undoing
  the fresher timestamp set by SVN change detection and sealing
  packages with stale version data
- `last_committed` is now monotonic — uses the same `CASE WHEN >` guard
  that `UpsertShellPackage` already had
- `last_synced_at` uses `COALESCE` to prevent nil overwrites
- Added 7-day periodic resync to both active and include-inactive query
  paths as a safety net for any edge cases
- Added test coverage for the 7-day resync behavior

## Production steps (in order)

1. Deploy the code
2. Run this SQL to unstick affected packages (uses RFC3339 to match stored format):

```sql
sqlite3 /srv/wp-packages/shared/storage/wppackages.db \
  "UPDATE packages
   SET last_committed = strftime('%Y-%m-%dT%H:%M:%SZ','now')
   WHERE is_active = 1
     AND last_synced_at > last_committed;"
```

3. Verify no packages remain stuck:

```sql
sqlite3 /srv/wp-packages/shared/storage/wppackages.db \
  "SELECT COUNT(*) AS requeued
   FROM packages
   WHERE is_active = 1
     AND last_synced_at > last_committed;"
```

Expected result: `0` (until new pipeline activity changes rows).

4. Trigger one pipeline run (or wait for the next scheduled cycle)

## Test plan

- [x] `make test` passes
- [x] `gofmt` and `golangci-lint` clean
- [ ] Deploy and run the SQL above
- [ ] Verify `ai` plugin shows 0.6.0 after next pipeline cycle
- [ ] Monitor logs for unexpected resync volume from the 7-day window

🤖 Generated with [Claude Code](https://claude.com/claude-code)