### PR TITLE
Remove 7-day periodic resync from update query

### DIFF
--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -280,9 +280,9 @@ func GetPackagesNeedingUpdate(ctx context.Context, db *sql.DB, opts UpdateQueryO
 
 	if !opts.Force && opts.Name == "" {
 		if opts.IncludeInactive {
-			query += ` AND (last_synced_at IS NULL OR last_committed > last_synced_at OR last_synced_at < datetime('now', '-7 days') OR (is_active = 0 AND (last_synced_at IS NULL OR last_synced_at < datetime('now', '-30 days'))))`
+			query += ` AND (last_synced_at IS NULL OR last_committed > last_synced_at OR (is_active = 0 AND (last_synced_at IS NULL OR last_synced_at < datetime('now', '-30 days'))))`
 		} else {
-			query += ` AND is_active = 1 AND (last_synced_at IS NULL OR last_committed > last_synced_at OR last_synced_at < datetime('now', '-7 days'))`
+			query += ` AND is_active = 1 AND (last_synced_at IS NULL OR last_committed > last_synced_at)`
 		}
 	} else if !opts.IncludeInactive && opts.Name == "" {
 		query += ` AND is_active = 1`

--- a/internal/packages/package_test.go
+++ b/internal/packages/package_test.go
@@ -293,33 +293,6 @@ func TestGetPackagesNeedingUpdate(t *testing.T) {
 	if pkgs[0].Name != "needs-update" {
 		t.Errorf("got name=%s, want needs-update", pkgs[0].Name)
 	}
-
-	// Package synced more than 7 days ago — should be picked up for periodic resync
-	staleSync := time.Now().UTC().AddDate(0, 0, -8)
-	stalePkg := &Package{
-		Type:          "plugin",
-		Name:          "stale-sync",
-		VersionsJSON:  "{}",
-		IsActive:      true,
-		LastCommitted: &lc,
-		LastSyncedAt:  &staleSync,
-	}
-	_ = UpsertPackage(ctx, database, stalePkg)
-
-	pkgs, err = GetPackagesNeedingUpdate(ctx, database, UpdateQueryOpts{Type: "plugin"})
-	if err != nil {
-		t.Fatalf("query after stale insert: %v", err)
-	}
-	found := false
-	for _, p := range pkgs {
-		if p.Name == "stale-sync" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected stale-sync to be included in packages needing update (7-day resync)")
-	}
 }
 
 func TestBatchUpsertShellPackages(t *testing.T) {


### PR DESCRIPTION
## Summary

- Removes the `last_synced_at < datetime('now', '-7 days')` condition added in #56
- This caused a full re-fetch of all ~61k packages from the WordPress.org API every 7 days, which is unnecessary ongoing churn
- The monotonic `last_committed` guard from #56 is the actual fix and is sufficient on its own

## Production steps (in order)

1. Deploy the code
2. Run this one-time SQL to catch any currently stuck packages:

```sql
sqlite3 /srv/wp-packages/shared/storage/wppackages.db \
  "UPDATE packages
   SET last_committed = strftime('%Y-%m-%dT%H:%M:%SZ','now')
   WHERE is_active = 1
     AND last_synced_at > last_committed;"
```

Note: this will re-queue all ~61k packages for API re-fetch. The update step will work through them over several pipeline runs.

3. Monitor pipeline logs to confirm packages are being re-fetched

## Test plan

- [x] `make test` passes
- [x] `gofmt` and `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)