### PR TITLE
Fix trunk-only packages being incorrectly marked as removed

### DIFF
--- a/cmd/wppackages/cmd/update.go
+++ b/cmd/wppackages/cmd/update.go
@@ -145,11 +145,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			}
 
 			if validVersions == 0 {
-				pkg.IsActive = false
-				if err := packages.DeactivatePackage(gCtx, application.DB, p.ID); err != nil {
-					application.Logger.Warn("failed to deactivate", "type", p.Type, "name", p.Name, "error", err)
-				}
-				deactivated.Add(1)
+				application.Logger.Debug("package has no tagged versions", "type", p.Type, "name", p.Name)
 			}
 
 			now := time.Now().UTC()

--- a/internal/http/templates/detail.html
+++ b/internal/http/templates/detail.html
@@ -29,6 +29,31 @@
 <div class="text-sm text-amber-900 min-w-0">
 {{if .TrunkOnly}}<p class="font-medium">No tagged releases in SVN</p>
 <p class="mt-1">This plugin releases exclusively via SVN trunk. Installing it will use <code class="text-xs font-mono bg-amber-100 px-1 py-0.5 rounded">dev-trunk</code> which is mutable &mdash; the contents may change without the version number changing, and it can't be pinned to a specific version. <a href="https://wordpress.org/support/plugin/{{.Package.Name}}/" class="font-medium underline underline-offset-2 hover:no-underline" rel="noopener">Ask the author to tag their releases</a> or see <a href="/untagged" class="font-medium underline underline-offset-2 hover:no-underline">all untagged plugins</a>.</p>
+<details class="mt-3">
+<summary class="font-medium cursor-pointer hover:underline">Workaround: install from trunk</summary>
+<div class="mt-2">
+<p class="text-amber-800 mb-2">Add this to your <code class="text-xs font-mono bg-amber-100 px-1 py-0.5 rounded">composer.json</code> repositories array <strong>above</strong> the WP Packages repository:</p>
+<div class="rounded-lg border border-amber-200 bg-white overflow-hidden">
+<div class="flex items-center justify-between px-3 py-1.5 bg-amber-50 border-b border-amber-200">
+<span class="text-xs text-amber-700">composer.json</span>
+<button onclick="copyDetailWorkaround()" class="text-xs text-amber-700 hover:text-amber-900 cursor-pointer" id="detail-workaround-btn">Copy</button>
+</div>
+<pre class="p-3 text-xs font-mono leading-relaxed overflow-x-auto text-gray-800" id="detail-workaround-code">{
+  "type": "package",
+  "package": {
+    "name": "wp-{{.Package.Type}}/{{.Package.Name}}",
+    "version": "{{.Package.WporgVersion}}",
+    "type": "wordpress-plugin",
+    "dist": {
+      "type": "zip",
+      "url": "https://downloads.wordpress.org/plugin/{{.Package.Name}}.zip"
+    }
+  }
+}</pre>
+</div>
+<p class="mt-2 text-xs text-amber-700">Note: this downloads from trunk, which is mutable &mdash; the contents may change without the version number changing.</p>
+</div>
+</details>
 {{else}}<p class="font-medium">Latest version not tagged in SVN</p>
 <p class="mt-1">WordPress.org reports version {{.Package.WporgVersion}} but it doesn't match any tagged release, so the latest version isn't available as a tagged release via Composer. <a href="https://wordpress.org/support/plugin/{{.Package.Name}}/" class="font-medium underline underline-offset-2 hover:no-underline" rel="noopener">Ask the author to tag their releases</a> or see <a href="/untagged" class="font-medium underline underline-offset-2 hover:no-underline">all untagged plugins</a>.</p>
 <details class="mt-3">

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -135,6 +135,7 @@ func UpsertShellPackage(ctx context.Context, db *sql.DB, pkgType, name string, l
 				THEN excluded.last_committed
 				ELSE packages.last_committed
 			END,
+			is_active = 1,
 			updated_at = excluded.updated_at`,
 		pkgType, name, timeStr(lastCommitted), now, now,
 	)
@@ -171,6 +172,7 @@ func BatchUpsertShellPackages(ctx context.Context, db *sql.DB, entries []ShellEn
 				THEN excluded.last_committed
 				ELSE packages.last_committed
 			END,
+			is_active = 1,
 			updated_at = excluded.updated_at`)
 	if err != nil {
 		return fmt.Errorf("preparing statement: %w", err)


### PR DESCRIPTION
## Summary
- Stop deactivating packages during update when they have no tagged versions but return valid API data (e.g. wp-term-order)
- SVN discovery now sets `is_active = 1` on rediscovery, so packages that were wrongly deactivated self-heal over time
- Add install-from-trunk workaround to the "No tagged releases in SVN" warning on detail pages

## Deployment
After deploying, run once to reactivate all affected packages:
```
wppackages update --include-inactive --force
```

## Test plan
- [ ] Run `wppackages update --name wp-term-order --include-inactive --force` and verify it stays active
- [ ] Verify genuinely removed packages (404 from WP.org) still get deactivated
- [ ] Verify trunk-only packages show the "No tagged releases in SVN" warning with workaround instead of "Package Removed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)