### PR TITLE
Deactivate closed plugins that return stub API responses

### DIFF
--- a/internal/wporg/client.go
+++ b/internal/wporg/client.go
@@ -186,8 +186,13 @@ func (c *Client) fetchJSON(ctx context.Context, rawURL string) (map[string]any, 
 			return nil, fmt.Errorf("parsing JSON response: %w", err)
 		}
 
-		// WordPress API returns {"error":"...","slug":"..."} for failures
+		// WordPress API returns {"error":"...","slug":"..."} for failures.
+		// Closed plugins return {"error":"closed",...} with a 200 status —
+		// treat them the same as a 404.
 		if errMsg, ok := result["error"]; ok {
+			if errMsg == "closed" {
+				return nil, ErrNotFound
+			}
 			return nil, fmt.Errorf("API error: %v", errMsg)
 		}
 


### PR DESCRIPTION
## Summary
- Closed plugins (e.g. `carbon-fields`) return a 200 from WP.org with `{"error":"closed"}` instead of a 404
- The client was treating this as a generic API error, so closed plugins were skipped rather than deactivated
- Now treat `"error":"closed"` as `ErrNotFound` so they follow the existing 404 deactivation path

## Deployment
After deploying, run once to deactivate the ~17k closed stubs that were reactivated:
```
wppackages update --force
```

## Test plan
- [x] Verify `carbon-fields` gets deactivated (`wppackages update --name carbon-fields --include-inactive --force`)
- [x] Verify `wp-term-order` stays active (trunk-only, not closed)
- [x] Verify true 404 packages still get deactivated

🤖 Generated with [Claude Code](https://claude.com/claude-code)