### PR TITLE
Stop SVN discovery from reactivating deactivated packages

### DIFF
--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -135,7 +135,6 @@ func UpsertShellPackage(ctx context.Context, db *sql.DB, pkgType, name string, l
 				THEN excluded.last_committed
 				ELSE packages.last_committed
 			END,
-			is_active = 1,
 			updated_at = excluded.updated_at`,
 		pkgType, name, timeStr(lastCommitted), now, now,
 	)
@@ -172,7 +171,6 @@ func BatchUpsertShellPackages(ctx context.Context, db *sql.DB, entries []ShellEn
 				THEN excluded.last_committed
 				ELSE packages.last_committed
 			END,
-			is_active = 1,
 			updated_at = excluded.updated_at`)
 	if err != nil {
 		return fmt.Errorf("preparing statement: %w", err)


### PR DESCRIPTION
## Summary
- Remove `is_active = 1` from the SVN discovery upsert's ON CONFLICT clause
- Deactivated packages (closed, removed) no longer get reactivated every cycle
- New packages discovered in SVN are still inserted as active

## Context
After #61 and #62, the deploy pipeline went from 2-3 minutes to 5-8 minutes. SVN discovery was unconditionally setting `is_active = 1` on all ~60k packages, causing the update command to re-fetch and re-deactivate thousands of closed/removed packages every cycle. The root cause fix (not deactivating on zero tagged versions) makes this reactivation unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)