### PR TITLE
Implement socket-activated zero-downtime deploy switchover

### DIFF
--- a/deploy/ansible/roles/caddy/templates/Caddyfile.j2
+++ b/deploy/ansible/roles/caddy/templates/Caddyfile.j2
@@ -19,8 +19,8 @@
 	# Reverse proxy to Go app — retry during restarts for zero-downtime deploys
 	reverse_proxy {{ go_upstream_addr | default("localhost" ~ go_listen_addr) }} {
 		header_up X-Real-IP {remote_host}
-		lb_try_duration 5s
-		lb_try_interval 250ms
+		lb_try_duration 10s
+		lb_try_interval 100ms
 		fail_duration 10s
 	}
 }

--- a/deploy/ansible/roles/wppackages/tasks/main.yml
+++ b/deploy/ansible/roles/wppackages/tasks/main.yml
@@ -7,17 +7,13 @@
     group: www-data
     mode: "0640"
 
-- name: Stop and disable legacy wppackages socket unit
-  service:
-    name: wppackages.socket
-    state: stopped
-    enabled: no
-  failed_when: false
-
-- name: Remove legacy wppackages socket unit
-  file:
-    path: /etc/systemd/system/wppackages.socket
-    state: absent
+- name: Deploy wppackages socket
+  template:
+    src: wppackages.socket.j2
+    dest: /etc/systemd/system/wppackages.socket
+    owner: root
+    group: root
+    mode: "0644"
   notify: Reload systemd
 
 - name: Deploy litestream service
@@ -163,6 +159,12 @@
 - name: Enable and start litestream service
   service:
     name: litestream
+    state: started
+    enabled: yes
+
+- name: Enable and start wppackages socket
+  service:
+    name: wppackages.socket
     state: started
     enabled: yes
 

--- a/deploy/ansible/roles/wppackages/templates/wppackages.service.j2
+++ b/deploy/ansible/roles/wppackages/templates/wppackages.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=WP Packages
 After=network.target litestream.service
-Requires=litestream.service
+Requires=litestream.service wppackages.socket
 
 [Service]
 Type=simple

--- a/deploy/ansible/roles/wppackages/templates/wppackages.socket.j2
+++ b/deploy/ansible/roles/wppackages/templates/wppackages.socket.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=WP Packages Socket
+
+[Socket]
+ListenStream={{ go_listen_addr }}
+NoDelay=true
+
+[Install]
+WantedBy=sockets.target

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -4,15 +4,42 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/roots/wp-packages/internal/app"
 )
+
+// systemdListener returns a net.Listener from a socket fd passed by systemd
+// socket activation (sd_listen_fds protocol). Returns nil if not running
+// under socket activation.
+func systemdListener() (net.Listener, error) {
+	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))
+	if err != nil || pid != os.Getpid() {
+		return nil, nil
+	}
+	nfds, err := strconv.Atoi(os.Getenv("LISTEN_FDS"))
+	if err != nil || nfds < 1 {
+		return nil, nil
+	}
+
+	f := os.NewFile(3, "systemd-socket")
+	ln, err := net.FileListener(f)
+	_ = f.Close()
+	if err != nil {
+		return nil, fmt.Errorf("creating listener from systemd fd: %w", err)
+	}
+
+	_ = os.Unsetenv("LISTEN_PID")
+	_ = os.Unsetenv("LISTEN_FDS")
+	return ln, nil
+}
 
 func ListenAndServe(a *app.App) error {
 	router := NewRouter(a)
@@ -29,13 +56,29 @@ func ListenAndServe(a *app.App) error {
 	}
 
 	errCh := make(chan error, 1)
-	go func() {
+
+	ln, err := systemdListener()
+	if err != nil {
+		return err
+	}
+
+	if ln != nil {
+		a.Logger.Info("using systemd socket activation")
+		go func() {
+			if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errCh <- fmt.Errorf("server error: %w", err)
+			}
+			close(errCh)
+		}()
+	} else {
 		a.Logger.Info("starting server", "addr", a.Config.Server.Addr)
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errCh <- fmt.Errorf("server error: %w", err)
-		}
-		close(errCh)
-	}()
+		go func() {
+			if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errCh <- fmt.Errorf("server error: %w", err)
+			}
+			close(errCh)
+		}()
+	}
 
 	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()


### PR DESCRIPTION
## Summary
- Implement systemd socket activation for zero-downtime deploy switchover
- Add Go-side `LISTEN_FDS` detection with fallback to normal listen for local dev
- Bump Caddy retry window (`lb_try_duration` 5s→10s, `lb_try_interval` 250ms→100ms) as safety net

## Why
We were seeing brief 502/503 responses during deploy because restarting the service drops the listening socket. Socket activation (`wppackages.socket`) keeps the socket open across service restarts — incoming connections queue at the kernel instead of failing.

Builds on #95 which separated Litestream into its own service, unblocking socket activation (the old `litestream -exec` wrapper wouldn't pass through the socket fd).

## Changes
- `internal/http/server.go` — `systemdListener()` consumes the fd passed by systemd via `LISTEN_FDS`/`LISTEN_PID`; falls back to `ListenAndServe` when not socket-activated (local dev)
- `templates/wppackages.socket.j2` — new systemd socket unit listening on `{{ go_listen_addr }}`
- `templates/wppackages.service.j2` — adds `Requires=wppackages.socket`
- `tasks/main.yml` — deploys and enables the socket unit before the service
- `Caddyfile.j2` — retry tuning as additional safety net

## Test plan
- [ ] Run `provision` and verify `wppackages.socket` is active (`systemctl status wppackages.socket`)
- [ ] Confirm `wppackages.service` starts via socket activation (`journalctl -u wppackages` shows "using systemd socket activation")
- [ ] Run `deploy` and monitor for 502/503 elimination during switchover
- [ ] Verify local dev still works without socket activation (normal `make dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)