### PR TITLE
Redirect deactivated packages to homepage instead of returning 410

### DIFF
--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -283,11 +283,11 @@ func handleDetail(a *app.App, tmpl *templateSet) http.HandlerFunc {
 		if err != nil {
 			gone := packageExistsInactive(r.Context(), a.DB, pkgType, name)
 			if gone {
-				w.WriteHeader(http.StatusGone)
+				http.Redirect(w, r, "https://wp-packages.org/", http.StatusFound)
 			} else {
 				w.WriteHeader(http.StatusNotFound)
+				render(w, r, tmpl.notFound, "layout", map[string]any{"Gone": false, "CDNURL": a.Config.R2.CDNPublicURL})
 			}
-			render(w, r, tmpl.notFound, "layout", map[string]any{"Gone": gone, "CDNURL": a.Config.R2.CDNPublicURL})
 			return
 		}
 


### PR DESCRIPTION
## Summary
- Deactivated packages now return a 302 redirect to https://wp-packages.org/ instead of a 410 Gone response
- Uses 302 (temporary) rather than 301 since packages may be reactivated in the future

🤖 Generated with [Claude Code](https://claude.com/claude-code)