### PR TITLE
Add latest updates section to homepage

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/roots/wp-packages/internal/blog"
 	"github.com/roots/wp-packages/internal/config"
 	"github.com/roots/wp-packages/internal/db"
 	"github.com/roots/wp-packages/internal/packagist"
@@ -19,6 +20,7 @@ type App struct {
 	DB        *sql.DB
 	Logger    *slog.Logger
 	Packagist *packagist.DownloadsCache
+	Blog      *blog.PostsCache
 }
 
 func New(cfg *config.Config) (*App, error) {
@@ -47,6 +49,7 @@ func New(cfg *config.Config) (*App, error) {
 		DB:        database,
 		Logger:    logger,
 		Packagist: packagist.NewDownloadsCache(logger),
+		Blog:      blog.NewPostsCache(logger),
 	}, nil
 }
 

--- a/internal/blog/posts.go
+++ b/internal/blog/posts.go
@@ -1,0 +1,83 @@
+package blog
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Post represents a blog post from the WordPress REST API.
+type Post struct {
+	Title string
+	Link  string
+}
+
+// PostsCache fetches and caches recent blog posts from roots.io.
+type PostsCache struct {
+	mu     sync.RWMutex
+	posts  []Post
+	logger *slog.Logger
+}
+
+func NewPostsCache(logger *slog.Logger) *PostsCache {
+	c := &PostsCache{logger: logger}
+	c.fetch()
+	go c.loop()
+	return c
+}
+
+// NewStubCache returns a PostsCache that never fetches, for use in tests.
+func NewStubCache() *PostsCache {
+	return &PostsCache{logger: slog.Default()}
+}
+
+func (c *PostsCache) Posts() []Post {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.posts
+}
+
+func (c *PostsCache) loop() {
+	ticker := time.NewTicker(15 * time.Minute)
+	for range ticker.C {
+		c.fetch()
+	}
+}
+
+func (c *PostsCache) fetch() {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get("https://roots.io/wp-json/wp/v2/posts?tags=22&per_page=5&_fields=title,link")
+	if err != nil {
+		c.logger.Warn("blog posts fetch failed", "error", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Warn("blog posts fetch failed", "status", resp.StatusCode)
+		return
+	}
+
+	var raw []struct {
+		Title struct {
+			Rendered string `json:"rendered"`
+		} `json:"title"`
+		Link string `json:"link"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		c.logger.Warn("blog posts decode failed", "error", err)
+		return
+	}
+
+	posts := make([]Post, len(raw))
+	for i, r := range raw {
+		posts[i] = Post{Title: r.Title.Rendered, Link: r.Link}
+	}
+
+	c.mu.Lock()
+	c.posts = posts
+	c.mu.Unlock()
+	c.logger.Info("blog posts updated", "count", len(posts))
+}

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -138,6 +138,7 @@ func handleIndex(a *app.App, tmpl *templateSet) http.HandlerFunc {
 			"CDNURL":     a.Config.R2.CDNPublicURL,
 			"OGImage":    ogImageURL(a.Config, "social/default.png"),
 			"JSONLD":     jsonLDData,
+			"BlogPosts":  a.Blog.Posts(),
 		})
 	}
 }

--- a/internal/http/templates/index.html
+++ b/internal/http/templates/index.html
@@ -90,4 +90,16 @@
 </div>
 
 </section>
+{{if .BlogPosts}}
+<section class="border-t border-gray-200/50 py-14">
+<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 text-center">
+<h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-6">Latest updates</h2>
+<ul class="space-y-2 max-w-xl mx-auto">
+{{range .BlogPosts}}
+<li><a href="{{.Link}}" class="text-sm font-medium text-brand-primary hover:underline">{{.Title}}</a></li>
+{{end}}
+</ul>
+</div>
+</section>
+{{end}}
 {{end}}


### PR DESCRIPTION
## Summary
- Adds a "Latest updates" section to the homepage above the sponsors area
- Fetches posts from the roots.io WordPress REST API
- Uses a background cache (`internal/blog`) that refreshes every 15 minutes, so posts stay current without redeploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)