### PR TITLE
Add Discord notifications for systemd pipeline failures

### DIFF
--- a/deploy/ansible/group_vars/production/vault.example.yml
+++ b/deploy/ansible/group_vars/production/vault.example.yml
@@ -9,6 +9,7 @@
 # - vault_r2_endpoint
 # - vault_r2_cdn_bucket
 # - vault_sentry_dsn
+# - vault_discord_webhook_url
 
 vault_r2_access_key_id: "REPLACE_ME"
 vault_r2_secret_access_key: "REPLACE_ME"
@@ -17,6 +18,7 @@ vault_r2_endpoint: "REPLACE_ME"
 vault_r2_cdn_bucket: "REPLACE_ME"
 vault_r2_litestream_bucket: "REPLACE_ME"
 vault_sentry_dsn: "REPLACE_ME"
+vault_discord_webhook_url: "REPLACE_ME"
 vault_ssl_certificate: |
   -----BEGIN CERTIFICATE-----
   REPLACE_ME

--- a/deploy/ansible/roles/app/templates/env.j2
+++ b/deploy/ansible/roles/app/templates/env.j2
@@ -20,3 +20,5 @@ R2_CDN_PUBLIC_URL={{ r2_cdn_public_url }}
 LITESTREAM_BUCKET={{ vault_r2_litestream_bucket }}
 
 SENTRY_DSN={{ vault_sentry_dsn }}
+
+DISCORD_WEBHOOK_URL={{ vault_discord_webhook_url | default('') }}

--- a/deploy/ansible/roles/wppackages/tasks/main.yml
+++ b/deploy/ansible/roles/wppackages/tasks/main.yml
@@ -31,6 +31,31 @@
     mode: "0644"
   notify: Reload systemd
 
+- name: Deploy pipeline failure notifier service
+  template:
+    src: wppackages-pipeline-notify@.service.j2
+    dest: /etc/systemd/system/wppackages-pipeline-notify@.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+
+- name: Ensure scripts directory exists
+  file:
+    path: "{{ app_root }}/shared/scripts"
+    state: directory
+    owner: deploy
+    group: www-data
+    mode: "0755"
+
+- name: Deploy pipeline failure notification script
+  template:
+    src: notify-pipeline-failure.sh.j2
+    dest: "{{ app_root }}/shared/scripts/notify-pipeline-failure.sh"
+    owner: deploy
+    group: www-data
+    mode: "0755"
+
 - name: Deploy pipeline timer unit
   template:
     src: wppackages-pipeline.timer.j2

--- a/deploy/ansible/roles/wppackages/templates/notify-pipeline-failure.sh.j2
+++ b/deploy/ansible/roles/wppackages/templates/notify-pipeline-failure.sh.j2
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
+  echo "DISCORD_WEBHOOK_URL not set, skipping notification"
+  exit 0
+fi
+
+DB="{{ db_path }}"
+LOG="{{ app_root }}/shared/storage/logs/pipeline.log"
+
+BUILD_ID=$(sqlite3 "$DB" "SELECT id FROM builds WHERE status='failed' ORDER BY started_at DESC LIMIT 1;" 2>/dev/null || echo "unknown")
+LOG_TAIL=$(tail -n 10 "$LOG" 2>/dev/null || echo "(no log output)")
+
+PAYLOAD=$(jq -n \
+  --arg title "Pipeline failed: $BUILD_ID" \
+  --arg logs "$LOG_TAIL" \
+  '{embeds: [{title: $title, description: ("```\n" + $logs + "\n```"), color: 16711680}]}')
+
+curl -sf --retry 2 --retry-delay 5 --max-time 10 -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL" || echo "Discord notification failed (unit: ${NOTIFY_UNIT:-unknown}), continuing"

--- a/deploy/ansible/roles/wppackages/templates/wppackages-pipeline-notify@.service.j2
+++ b/deploy/ansible/roles/wppackages/templates/wppackages-pipeline-notify@.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Discord notification for %i failure
+
+[Service]
+Type=oneshot
+User=deploy
+Group=www-data
+EnvironmentFile={{ app_root }}/shared/.env
+Environment=NOTIFY_UNIT=%i
+ExecStart={{ app_root }}/shared/scripts/notify-pipeline-failure.sh

--- a/deploy/ansible/roles/wppackages/templates/wppackages-pipeline.service.j2
+++ b/deploy/ansible/roles/wppackages/templates/wppackages-pipeline.service.j2
@@ -10,3 +10,4 @@ ExecStart={{ app_root }}/current/{{ go_binary_name }} pipeline --discover-source
 StandardOutput=append:{{ app_root }}/shared/storage/logs/pipeline.log
 StandardError=append:{{ app_root }}/shared/storage/logs/pipeline.log
 EnvironmentFile={{ app_root }}/shared/.env
+OnFailure=wppackages-pipeline-notify@%n.service

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -138,6 +138,7 @@ All commands accept:
 | `R2_BUCKET` | R2 bucket name |
 | `R2_ENDPOINT` | R2 S3-compatible endpoint URL |
 | `LITESTREAM_BUCKET` | R2 bucket for Litestream DB backup |
+| `DISCORD_WEBHOOK_URL` | Discord webhook for pipeline failure notifications (optional) |
 
 ## Admin Bootstrap
 


### PR DESCRIPTION
## Summary
- Adds a systemd `OnFailure=` unit that triggers a Discord webhook when `wppackages-pipeline.service` fails
- Notifier script queries latest failed build ID from SQLite and includes last 10 lines of `pipeline.log`
- Webhook URL wired through vault -> `.env`, with safe Jinja default so deploys work if unset
- Curl is best-effort with retries/timeouts, so notifier failures do not fail the pipeline or deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)