### PR TITLE
Retry SQLite writes on SQLITE_BUSY

### DIFF
--- a/internal/db/retry.go
+++ b/internal/db/retry.go
@@ -1,0 +1,65 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	sqlite "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+const (
+	busyMaxRetries = 3
+	busyRetryDelay = 2 * time.Second
+)
+
+// IsSQLiteBusy returns true if the error is a SQLITE_BUSY error.
+func IsSQLiteBusy(err error) bool {
+	var sqliteErr *sqlite.Error
+	if errors.As(err, &sqliteErr) {
+		return sqliteErr.Code() == sqlite3.SQLITE_BUSY
+	}
+	return false
+}
+
+// BeginTxRetry wraps db.BeginTx with retry on SQLITE_BUSY.
+func BeginTxRetry(ctx context.Context, database *sql.DB, opts *sql.TxOptions) (*sql.Tx, error) {
+	var tx *sql.Tx
+	var err error
+	for attempt := 0; attempt <= busyMaxRetries; attempt++ {
+		tx, err = database.BeginTx(ctx, opts)
+		if err == nil || !IsSQLiteBusy(err) {
+			return tx, err
+		}
+		if attempt < busyMaxRetries {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(busyRetryDelay):
+			}
+		}
+	}
+	return nil, err
+}
+
+// ExecRetry wraps db.ExecContext with retry on SQLITE_BUSY.
+func ExecRetry(ctx context.Context, database *sql.DB, query string, args ...any) (sql.Result, error) {
+	var result sql.Result
+	var err error
+	for attempt := 0; attempt <= busyMaxRetries; attempt++ {
+		result, err = database.ExecContext(ctx, query, args...)
+		if err == nil || !IsSQLiteBusy(err) {
+			return result, err
+		}
+		if attempt < busyMaxRetries {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(busyRetryDelay):
+			}
+		}
+	}
+	return result, err
+}

--- a/internal/db/retry_test.go
+++ b/internal/db/retry_test.go
@@ -1,0 +1,106 @@
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestIsSQLiteBusy(t *testing.T) {
+	if IsSQLiteBusy(nil) {
+		t.Error("expected nil to return false")
+	}
+	if IsSQLiteBusy(os.ErrNotExist) {
+		t.Error("expected non-sqlite error to return false")
+	}
+}
+
+func TestIsSQLiteBusy_RealContention(t *testing.T) {
+	// Create a file-backed DB so two connections can contend.
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	db1, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db1.Close() }()
+
+	// Use default journal mode (not WAL) and zero busy timeout to force immediate SQLITE_BUSY.
+	_, _ = db1.Exec("PRAGMA busy_timeout = 0")
+	_, _ = db1.Exec("PRAGMA journal_mode = DELETE")
+	_, _ = db1.Exec("CREATE TABLE test (id INTEGER PRIMARY KEY, val TEXT)")
+	_, _ = db1.Exec("INSERT INTO test VALUES (1, 'a')")
+
+	db2, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db2.Close() }()
+	_, _ = db2.Exec("PRAGMA busy_timeout = 0")
+	_, _ = db2.Exec("PRAGMA journal_mode = DELETE")
+
+	// db1 holds a write transaction.
+	tx, err := db1.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	_, _ = tx.Exec("UPDATE test SET val = 'b' WHERE id = 1")
+
+	// db2 tries to write — should get SQLITE_BUSY.
+	_, err = db2.Exec("UPDATE test SET val = 'c' WHERE id = 1")
+	if err == nil {
+		t.Fatal("expected SQLITE_BUSY error, got nil")
+	}
+	if !IsSQLiteBusy(err) {
+		t.Errorf("expected IsSQLiteBusy=true, got false for error: %v", err)
+	}
+}
+
+func TestBeginTxRetry_ContextCancel(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	_, _ = db.Exec("CREATE TABLE test (id INTEGER PRIMARY KEY)")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err = BeginTxRetry(ctx, db, nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Error("expected error with cancelled context")
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("should not have retried with cancelled context, took %v", elapsed)
+	}
+}
+
+func TestExecRetry_Success(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	_, _ = db.Exec("CREATE TABLE test (id INTEGER PRIMARY KEY, val TEXT)")
+
+	_, err = ExecRetry(context.Background(), db, "INSERT INTO test VALUES (1, 'hello')")
+	if err != nil {
+		t.Fatalf("ExecRetry failed: %v", err)
+	}
+
+	var val string
+	_ = db.QueryRow("SELECT val FROM test WHERE id = 1").Scan(&val)
+	if val != "hello" {
+		t.Errorf("val = %q, want 'hello'", val)
+	}
+}

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	sqldb "github.com/roots/wp-packages/internal/db"
 	"github.com/roots/wp-packages/internal/version"
 )
 
@@ -82,7 +83,7 @@ func timeStr(t *time.Time) *string {
 func UpsertPackage(ctx context.Context, db *sql.DB, pkg *Package) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 
-	_, err := db.ExecContext(ctx, `
+	_, err := sqldb.ExecRetry(ctx, db, `
 		INSERT INTO packages (
 			type, name, display_name, description, author, homepage, slug_url,
 			versions_json, downloads, active_installs,
@@ -134,7 +135,7 @@ func UpsertPackage(ctx context.Context, db *sql.DB, pkg *Package) error {
 func UpsertShellPackage(ctx context.Context, db *sql.DB, pkgType, name string, lastCommitted *time.Time) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 
-	_, err := db.ExecContext(ctx, `
+	_, err := sqldb.ExecRetry(ctx, db, `
 		INSERT INTO packages (type, name, last_committed, is_active, versions_json, created_at, updated_at)
 		VALUES (?, ?, ?, 1, '{}', ?, ?)
 		ON CONFLICT(type, name) DO UPDATE SET
@@ -164,7 +165,7 @@ func BatchUpsertShellPackages(ctx context.Context, db *sql.DB, entries []ShellEn
 	if len(entries) == 0 {
 		return nil
 	}
-	tx, err := db.BeginTx(ctx, nil)
+	tx, err := sqldb.BeginTxRetry(ctx, db, nil)
 	if err != nil {
 		return fmt.Errorf("beginning transaction: %w", err)
 	}
@@ -199,7 +200,7 @@ func BatchUpsertPackages(ctx context.Context, db *sql.DB, pkgs []*Package) error
 	if len(pkgs) == 0 {
 		return nil
 	}
-	tx, err := db.BeginTx(ctx, nil)
+	tx, err := sqldb.BeginTxRetry(ctx, db, nil)
 	if err != nil {
 		return fmt.Errorf("beginning transaction: %w", err)
 	}
@@ -341,7 +342,7 @@ func GetPackagesNeedingUpdate(ctx context.Context, db *sql.DB, opts UpdateQueryO
 
 // DeactivatePackage sets is_active = 0 for a package.
 func DeactivatePackage(ctx context.Context, db *sql.DB, id int64) error {
-	_, err := db.ExecContext(ctx,
+	_, err := sqldb.ExecRetry(ctx, db,
 		`UPDATE packages SET is_active = 0, updated_at = ? WHERE id = ?`,
 		time.Now().UTC().Format(time.RFC3339), id,
 	)
@@ -353,7 +354,7 @@ func DeactivatePackage(ctx context.Context, db *sql.DB, id int64) error {
 
 // ReactivatePackage sets is_active = 1 for a package.
 func ReactivatePackage(ctx context.Context, db *sql.DB, id int64) error {
-	_, err := db.ExecContext(ctx,
+	_, err := sqldb.ExecRetry(ctx, db,
 		`UPDATE packages SET is_active = 1, updated_at = ? WHERE id = ?`,
 		time.Now().UTC().Format(time.RFC3339), id,
 	)
@@ -392,7 +393,7 @@ func GetAllPackages(ctx context.Context, db *sql.DB, pkgType string) ([]*Package
 
 // StartStatusCheck inserts a new status_checks row and returns its ID.
 func StartStatusCheck(ctx context.Context, db *sql.DB, started time.Time) (int64, error) {
-	res, err := db.ExecContext(ctx,
+	res, err := sqldb.ExecRetry(ctx, db,
 		`INSERT INTO status_checks (started_at, status) VALUES (?, 'running')`,
 		started.Format(time.RFC3339))
 	if err != nil {
@@ -414,7 +415,7 @@ func FinishStatusCheck(ctx context.Context, db *sql.DB, id int64, started time.T
 	} else if failed > 0 {
 		status = "completed_with_errors"
 	}
-	_, err := db.ExecContext(ctx, `
+	_, err := sqldb.ExecRetry(ctx, db, `
 		UPDATE status_checks SET
 			finished_at = ?, status = ?, checked = ?, deactivated = ?,
 			reactivated = ?, failed = ?, duration_seconds = ?, error_message = ?
@@ -468,7 +469,7 @@ func GetStatusChecks(ctx context.Context, db *sql.DB, limit int) ([]StatusCheck,
 
 // RefreshSiteStats recomputes the package_stats row from the packages table.
 func RefreshSiteStats(ctx context.Context, db *sql.DB) error {
-	_, err := db.ExecContext(ctx, `
+	_, err := sqldb.ExecRetry(ctx, db, `
 		INSERT OR REPLACE INTO package_stats (id, active_plugins, active_themes, plugin_installs, theme_installs, installs_30d, updated_at)
 		SELECT 1,
 			COALESCE(SUM(CASE WHEN type = 'plugin' THEN 1 ELSE 0 END), 0),
@@ -495,7 +496,7 @@ func MarkPackagesChanged(ctx context.Context, db *sql.DB, pkgType string, slugRe
 
 	now := time.Now().UTC().Format(time.RFC3339)
 
-	tx, err := db.BeginTx(ctx, nil)
+	tx, err := sqldb.BeginTxRetry(ctx, db, nil)
 	if err != nil {
 		return 0, fmt.Errorf("beginning transaction: %w", err)
 	}
@@ -533,7 +534,7 @@ func BackfillTrunkRevisions(ctx context.Context, db *sql.DB, slugRevisions map[s
 		return 0, nil
 	}
 
-	tx, err := db.BeginTx(ctx, nil)
+	tx, err := sqldb.BeginTxRetry(ctx, db, nil)
 	if err != nil {
 		return 0, fmt.Errorf("beginning transaction: %w", err)
 	}

--- a/internal/packages/site_meta.go
+++ b/internal/packages/site_meta.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	sqldb "github.com/roots/wp-packages/internal/db"
 )
 
 // GetMeta retrieves a value from site_meta by key. Returns "" if not found.
@@ -21,7 +23,7 @@ func GetMeta(ctx context.Context, db *sql.DB, key string) (string, error) {
 
 // SetMeta inserts or updates a value in site_meta.
 func SetMeta(ctx context.Context, db *sql.DB, key, value string) error {
-	_, err := db.ExecContext(ctx, `
+	_, err := sqldb.ExecRetry(ctx, db, `
 		INSERT INTO site_meta (key, value) VALUES (?, ?)
 		ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
 		key, value)

--- a/internal/packages/sync.go
+++ b/internal/packages/sync.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/roots/wp-packages/internal/db"
 )
 
 // SyncRun holds both the logical sync run ID (for package tracking) and the
@@ -16,8 +18,8 @@ type SyncRun struct {
 }
 
 // AllocateSyncRunID atomically allocates a new sync run ID and creates a sync_runs record.
-func AllocateSyncRunID(ctx context.Context, db *sql.DB) (*SyncRun, error) {
-	tx, err := db.BeginTx(ctx, nil)
+func AllocateSyncRunID(ctx context.Context, database *sql.DB) (*SyncRun, error) {
+	tx, err := db.BeginTxRetry(ctx, database, nil)
 	if err != nil {
 		return nil, fmt.Errorf("beginning transaction: %w", err)
 	}
@@ -53,11 +55,11 @@ func AllocateSyncRunID(ctx context.Context, db *sql.DB) (*SyncRun, error) {
 }
 
 // FinishSyncRun marks a sync run as completed with stats.
-func FinishSyncRun(ctx context.Context, db *sql.DB, rowID int64, status string, stats map[string]any) error {
+func FinishSyncRun(ctx context.Context, database *sql.DB, rowID int64, status string, stats map[string]any) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	metaJSON, _ := json.Marshal(stats)
 
-	_, err := db.ExecContext(ctx,
+	_, err := db.ExecRetry(ctx, database,
 		`UPDATE sync_runs SET finished_at = ?, status = ?, meta_json = ? WHERE id = ?`,
 		now, status, string(metaJSON), rowID,
 	)


### PR DESCRIPTION
## Summary

- Adds `BeginTxRetry` and `ExecRetry` helpers in `internal/db` with up to 3 retries and 2s backoff on SQLITE_BUSY
- Applies retries to pipeline/check-status write paths across `internal/packages` (`package.go`, `site_meta.go`, `sync.go`)
- Reduces intermittent "database is locked" failures caused by brief Litestream WAL replication lock windows
- Adds tests covering real contention busy detection, context-cancel short-circuit, and success path

🤖 Generated with [Claude Code](https://claude.com/claude-code)