### PR TITLE
Stop polling permanently-closed plugins

### DIFF
--- a/cmd/wppackages/cmd/check_status.go
+++ b/cmd/wppackages/cmd/check_status.go
@@ -43,7 +43,7 @@ func runCheckStatus(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("recording status check: %w", err)
 	}
 
-	var checked, deactivated, reactivated, failed atomic.Int64
+	var checked, deactivated, tombstoned, reactivated, failed atomic.Int64
 	var runErr error
 	defer func() {
 		_ = packages.FinishStatusCheck(ctx, application.DB, runID, started,
@@ -80,7 +80,16 @@ func runCheckStatus(cmd *cobra.Command, args []string) error {
 			}
 
 			if fetchErr != nil {
-				if errors.Is(fetchErr, wporg.ErrNotFound) {
+				if errors.Is(fetchErr, wporg.ErrClosedPermanent) {
+					if err := packages.MarkPermanentlyClosed(gCtx, application.DB, p.ID); err != nil {
+						application.Logger.Warn("failed to tombstone", "type", p.Type, "name", p.Name, "error", err)
+						failed.Add(1)
+					} else {
+						tombstoned.Add(1)
+						application.Logger.Info("tombstoned permanently-closed package", "type", p.Type, "name", p.Name)
+						packages.RecordStatusCheckChange(gCtx, application.DB, runID, p.Type, p.Name, "tombstoned")
+					}
+				} else if errors.Is(fetchErr, wporg.ErrNotFound) {
 					if p.IsActive {
 						if err := packages.DeactivatePackage(gCtx, application.DB, p.ID); err != nil {
 							application.Logger.Warn("failed to deactivate", "type", p.Type, "name", p.Name, "error", err)
@@ -113,6 +122,7 @@ func runCheckStatus(cmd *cobra.Command, args []string) error {
 					"checked", total,
 					"total", len(pkgs),
 					"deactivated", deactivated.Load(),
+					"tombstoned", tombstoned.Load(),
 					"reactivated", reactivated.Load(),
 					"failed", failed.Load(),
 				)
@@ -126,6 +136,7 @@ func runCheckStatus(cmd *cobra.Command, args []string) error {
 	application.Logger.Info("check-status complete",
 		"checked", checked.Load(),
 		"deactivated", deactivated.Load(),
+		"tombstoned", tombstoned.Load(),
 		"reactivated", reactivated.Load(),
 		"failed", failed.Load(),
 	)

--- a/cmd/wppackages/cmd/update.go
+++ b/cmd/wppackages/cmd/update.go
@@ -71,7 +71,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	const writeBatchSize = 100
 
-	var succeeded, failed, deactivated, changed, staleRetried, staleExpired atomic.Int64
+	var succeeded, failed, deactivated, tombstoned, changed, staleRetried, staleExpired atomic.Int64
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(concurrency)
 
@@ -119,7 +119,14 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			}
 
 			if fetchErr != nil {
-				if errors.Is(fetchErr, wporg.ErrNotFound) {
+				if errors.Is(fetchErr, wporg.ErrClosedPermanent) {
+					if err := packages.MarkPermanentlyClosed(gCtx, application.DB, p.ID); err != nil {
+						application.Logger.Warn("failed to tombstone package", "type", p.Type, "name", p.Name, "error", err)
+						failed.Add(1)
+					} else {
+						tombstoned.Add(1)
+					}
+				} else if errors.Is(fetchErr, wporg.ErrNotFound) {
 					if err := packages.DeactivatePackage(gCtx, application.DB, p.ID); err != nil {
 						application.Logger.Warn("failed to deactivate 404 package", "type", p.Type, "name", p.Name, "error", err)
 					}
@@ -128,7 +135,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 					application.Logger.Warn("failed to fetch", "type", p.Type, "name", p.Name, "error", fetchErr)
 					failed.Add(1)
 				}
-				total := succeeded.Load() + failed.Load() + deactivated.Load()
+				total := succeeded.Load() + failed.Load() + deactivated.Load() + tombstoned.Load()
 				if total%500 == 0 {
 					application.Logger.Info("update progress",
 						"completed", total,
@@ -136,6 +143,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 						"succeeded", succeeded.Load(),
 						"failed", failed.Load(),
 						"deactivated", deactivated.Load(),
+						"tombstoned", tombstoned.Load(),
 					)
 				}
 				return nil
@@ -191,7 +199,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			succeeded.Add(1)
 			writeCh <- pkg
 
-			total := succeeded.Load() + failed.Load() + deactivated.Load()
+			total := succeeded.Load() + failed.Load() + deactivated.Load() + tombstoned.Load()
 			if total%500 == 0 {
 				application.Logger.Info("update progress",
 					"completed", total,
@@ -199,6 +207,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 					"succeeded", succeeded.Load(),
 					"failed", failed.Load(),
 					"deactivated", deactivated.Load(),
+					"tombstoned", tombstoned.Load(),
 				)
 			}
 			application.Logger.Debug("updated package", "type", p.Type, "name", p.Name, "versions", validVersions)
@@ -218,6 +227,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		"changed":       changed.Load(),
 		"failed":        failed.Load(),
 		"deactivated":   deactivated.Load(),
+		"tombstoned":    tombstoned.Load(),
 		"stale_retried": staleRetried.Load(),
 		"stale_expired": staleExpired.Load(),
 	}
@@ -240,6 +250,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		"changed", changed.Load(),
 		"failed", failed.Load(),
 		"deactivated", deactivated.Load(),
+		"tombstoned", tombstoned.Load(),
 		"stale_retried", staleRetried.Load(),
 		"stale_expired", staleExpired.Load(),
 	)

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -28,6 +28,7 @@ type Package struct {
 	Rating                  *float64
 	NumRatings              int
 	IsActive                bool
+	PermanentlyClosed       bool
 	LastCommitted           *time.Time
 	LastSyncedAt            *time.Time
 	LastSyncRunID           *int64
@@ -143,7 +144,8 @@ func UpsertShellPackage(ctx context.Context, db *sql.DB, pkgType, name string, l
 				THEN excluded.last_committed
 				ELSE packages.last_committed
 			END,
-			updated_at = excluded.updated_at`,
+			updated_at = excluded.updated_at
+		WHERE packages.permanently_closed = 0`,
 		pkgType, name, timeStr(lastCommitted), now, now,
 	)
 	if err != nil {
@@ -179,7 +181,8 @@ func BatchUpsertShellPackages(ctx context.Context, db *sql.DB, entries []ShellEn
 				THEN excluded.last_committed
 				ELSE packages.last_committed
 			END,
-			updated_at = excluded.updated_at`)
+			updated_at = excluded.updated_at
+		WHERE packages.permanently_closed = 0`)
 	if err != nil {
 		return fmt.Errorf("preparing statement: %w", err)
 	}
@@ -271,7 +274,7 @@ type UpdateQueryOpts struct {
 
 // GetPackagesNeedingUpdate returns packages that should be updated.
 func GetPackagesNeedingUpdate(ctx context.Context, db *sql.DB, opts UpdateQueryOpts) ([]*Package, error) {
-	query := `SELECT id, type, name, last_committed, last_synced_at, is_active, versions_json, content_hash, trunk_revision FROM packages WHERE 1=1`
+	query := `SELECT id, type, name, last_committed, last_synced_at, is_active, versions_json, content_hash, trunk_revision FROM packages WHERE permanently_closed = 0`
 	var args []any
 
 	if opts.Name != "" {
@@ -352,6 +355,22 @@ func DeactivatePackage(ctx context.Context, db *sql.DB, id int64) error {
 	return nil
 }
 
+// MarkPermanentlyClosed tombstones a package so it's excluded from discovery
+// and polling entirely. The row is kept (with is_active = 0 and
+// permanently_closed = 1) so SVN discovery dedup still works and audit
+// history via status_check_changes is preserved.
+func MarkPermanentlyClosed(ctx context.Context, db *sql.DB, id int64) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := db.ExecContext(ctx,
+		`UPDATE packages SET permanently_closed = 1, is_active = 0, updated_at = ?, content_changed_at = ? WHERE id = ?`,
+		now, now, id,
+	)
+	if err != nil {
+		return fmt.Errorf("marking package %d permanently closed: %w", id, err)
+	}
+	return nil
+}
+
 // ReactivatePackage sets is_active = 1 for a package.
 func ReactivatePackage(ctx context.Context, db *sql.DB, id int64) error {
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -367,7 +386,7 @@ func ReactivatePackage(ctx context.Context, db *sql.DB, id int64) error {
 
 // GetAllPackages returns all packages, optionally filtered by type.
 func GetAllPackages(ctx context.Context, db *sql.DB, pkgType string) ([]*Package, error) {
-	query := `SELECT id, type, name, is_active FROM packages WHERE 1=1`
+	query := `SELECT id, type, name, is_active FROM packages WHERE permanently_closed = 0`
 	var args []any
 
 	if pkgType != "" && pkgType != "all" {

--- a/internal/packages/package_test.go
+++ b/internal/packages/package_test.go
@@ -36,6 +36,7 @@ func setupTestDB(t *testing.T) *sql.DB {
 			rating REAL,
 			num_ratings INTEGER NOT NULL DEFAULT 0,
 			is_active INTEGER NOT NULL DEFAULT 1,
+			permanently_closed INTEGER NOT NULL DEFAULT 0,
 			last_committed TEXT,
 			last_synced_at TEXT,
 			last_sync_run_id INTEGER,

--- a/internal/wporg/client.go
+++ b/internal/wporg/client.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"errors"
@@ -19,6 +20,12 @@ import (
 
 // ErrNotFound is returned when a package does not exist on WordPress.org.
 var ErrNotFound = errors.New("package not found")
+
+// ErrClosedPermanent is returned when a package is closed with "This closure
+// is permanent." in its description — these will never reopen and can be
+// tombstoned to stop polling. Temporary or unknown closures still return
+// ErrNotFound.
+var ErrClosedPermanent = errors.New("package closed permanently")
 
 type Client struct {
 	http       *http.Client
@@ -172,10 +179,11 @@ func (c *Client) fetchJSON(ctx context.Context, rawURL string) (map[string]any, 
 			continue
 		}
 
-		if resp.StatusCode == http.StatusNotFound {
-			return nil, ErrNotFound
-		}
-		if resp.StatusCode != http.StatusOK {
+		// wp.org returns HTTP 404 for closed plugins with a JSON body
+		// describing the closure, so we can't short-circuit on status code
+		// alone — try to parse the body first and only fall back to
+		// ErrNotFound if it doesn't look like a closure payload.
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
 			lastErr = fmt.Errorf("unexpected status %d", resp.StatusCode)
 			c.logger.Warn("API returned error status, retrying", "status", resp.StatusCode, "attempt", attempt+1)
 			continue
@@ -183,17 +191,31 @@ func (c *Client) fetchJSON(ctx context.Context, rawURL string) (map[string]any, 
 
 		var result map[string]any
 		if err := json.Unmarshal(body, &result); err != nil {
+			if resp.StatusCode == http.StatusNotFound {
+				return nil, ErrNotFound
+			}
 			return nil, fmt.Errorf("parsing JSON response: %w", err)
 		}
 
-		// WordPress API returns {"error":"...","slug":"..."} for failures.
-		// Closed plugins return {"error":"closed",...} with a 200 status —
-		// treat them the same as a 404.
+		// Closed plugins arrive as {"error":"closed","description":"...","closed":true,...}.
+		// The `description` field carries the closure blurb — if it contains
+		// "This closure is permanent." the row can be tombstoned. Anything
+		// else (temporary, unknown) falls through to ErrNotFound.
 		if errMsg, ok := result["error"]; ok {
 			if errMsg == "closed" {
+				if desc, _ := result["description"].(string); strings.Contains(desc, "This closure is permanent.") {
+					return nil, ErrClosedPermanent
+				}
+				return nil, ErrNotFound
+			}
+			if resp.StatusCode == http.StatusNotFound {
 				return nil, ErrNotFound
 			}
 			return nil, fmt.Errorf("API error: %v", errMsg)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, ErrNotFound
 		}
 
 		return result, nil

--- a/internal/wporg/client_test.go
+++ b/internal/wporg/client_test.go
@@ -2,6 +2,7 @@ package wporg
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -62,6 +63,43 @@ func TestFetchJSON_APIError(t *testing.T) {
 	_, err := c.fetchJSON(context.Background(), srv.URL)
 	if err == nil {
 		t.Fatal("expected error for API error response")
+	}
+}
+
+// wp.org serves closed-plugin JSON with an HTTP 404 status code, so the
+// fixture handlers below mirror that to catch the status-code short-circuit
+// regression.
+
+func TestFetchJSON_ClosedPermanent(t *testing.T) {
+	body := `{"error":"closed","name":"YALW","slug":"yalw","description":"This plugin has been closed as of April 9, 2026 and is not available for download. This closure is permanent. Reason: Author Request.","closed":true,"closed_date":"2026-04-09","reason":"author-request","reason_text":"Author Request"}`
+	c, srv := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	_, err := c.fetchJSON(context.Background(), srv.URL)
+	if !errors.Is(err, ErrClosedPermanent) {
+		t.Fatalf("got err=%v, want ErrClosedPermanent", err)
+	}
+}
+
+func TestFetchJSON_ClosedTemporary(t *testing.T) {
+	body := `{"error":"closed","name":"Temp","slug":"temp","description":"This plugin has been closed as of April 9, 2026 and is not available for download. This closure is temporary, pending a full review.","closed":true,"closed_date":"2026-04-09","reason":false,"reason_text":false}`
+	c, srv := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	_, err := c.fetchJSON(context.Background(), srv.URL)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("got err=%v, want ErrNotFound", err)
+	}
+	if errors.Is(err, ErrClosedPermanent) {
+		t.Fatalf("temporary closure should not return ErrClosedPermanent")
 	}
 }
 

--- a/migrations/027_add_permanently_closed.sql
+++ b/migrations/027_add_permanently_closed.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE packages ADD COLUMN permanently_closed INTEGER NOT NULL DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE packages DROP COLUMN permanently_closed;


### PR DESCRIPTION
## Summary
- Parse `"This closure is permanent."` from wp.org's closed-plugin responses and return a new `ErrClosedPermanent` from the wporg client
- Add a `permanently_closed` column to `packages`; `check-status` and `update` tombstone matching rows via `MarkPermanentlyClosed`
- Exclude tombstones from `GetAllPackages`, `GetPackagesNeedingUpdate`, and the SVN shell upsert's `ON CONFLICT DO UPDATE` so they're never polled or resurrected
- First `check-status` run tombstoned ~9k plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)