### PR TITLE
Add API endpoint for closed plugins/themes

### DIFF
--- a/internal/http/api.go
+++ b/internal/http/api.go
@@ -1,0 +1,15 @@
+package http
+
+import "strings"
+
+// parsePkgType normalizes the {type} path segment used by the public API.
+// It accepts both the composer-style "wp-plugin"/"wp-theme" and the bare
+// "plugin"/"theme" forms, returning the bare form. ok is false for anything
+// else, which callers should treat as 404.
+func parsePkgType(raw string) (string, bool) {
+	t := strings.TrimPrefix(raw, "wp-")
+	if t == "plugin" || t == "theme" {
+		return t, true
+	}
+	return "", false
+}

--- a/internal/http/api_closed_packages.go
+++ b/internal/http/api_closed_packages.go
@@ -7,7 +7,17 @@ import (
 	"github.com/roots/wp-packages/internal/app"
 )
 
-func handleAPIClosedPackages(a *app.App) http.HandlerFunc {
+// handleAPIClosedPackages returns slugs of closed packages. When permanentOnly
+// is true, the result is restricted to packages flagged permanently_closed = 1
+// (a stable subset of is_active = 0). Otherwise it returns every is_active = 0
+// row, which includes both temporary and permanent closures.
+func handleAPIClosedPackages(a *app.App, permanentOnly bool) http.HandlerFunc {
+	where := "is_active = 0"
+	if permanentOnly {
+		where = "permanently_closed = 1"
+	}
+	query := `SELECT name FROM packages WHERE type = ? AND ` + where + ` ORDER BY name`
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		pkgType, ok := parsePkgType(r.PathValue("type"))
 		if !ok {
@@ -15,14 +25,9 @@ func handleAPIClosedPackages(a *app.App) http.HandlerFunc {
 			return
 		}
 
-		rows, err := a.DB.QueryContext(r.Context(),
-			`SELECT name FROM packages
-			 WHERE type = ? AND permanently_closed = 1
-			 ORDER BY name`,
-			pkgType,
-		)
+		rows, err := a.DB.QueryContext(r.Context(), query, pkgType)
 		if err != nil {
-			a.Logger.Error("querying closed packages", "error", err, "type", pkgType)
+			a.Logger.Error("querying closed packages", "error", err, "type", pkgType, "permanent", permanentOnly)
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}

--- a/internal/http/api_closed_packages.go
+++ b/internal/http/api_closed_packages.go
@@ -1,0 +1,51 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/roots/wp-packages/internal/app"
+)
+
+func handleAPIClosedPackages(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		pkgType, ok := parsePkgType(r.PathValue("type"))
+		if !ok {
+			http.Error(w, "unknown package type", http.StatusNotFound)
+			return
+		}
+
+		rows, err := a.DB.QueryContext(r.Context(),
+			`SELECT name FROM packages
+			 WHERE type = ? AND permanently_closed = 1
+			 ORDER BY name`,
+			pkgType,
+		)
+		if err != nil {
+			a.Logger.Error("querying closed packages", "error", err, "type", pkgType)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		defer func() { _ = rows.Close() }()
+
+		slugs := []string{}
+		for rows.Next() {
+			var name string
+			if err := rows.Scan(&name); err != nil {
+				a.Logger.Error("scanning closed packages", "error", err)
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
+			slugs = append(slugs, name)
+		}
+		if err := rows.Err(); err != nil {
+			a.Logger.Error("iterating closed packages", "error", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		_ = json.NewEncoder(w).Encode(slugs)
+	}
+}

--- a/internal/http/api_closed_packages_test.go
+++ b/internal/http/api_closed_packages_test.go
@@ -1,0 +1,147 @@
+package http
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/roots/wp-packages/internal/app"
+	"github.com/roots/wp-packages/internal/config"
+	"github.com/roots/wp-packages/internal/db"
+)
+
+func setupClosedTestApp(t *testing.T) *app.App {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	_, err = database.Exec(`
+		CREATE TABLE packages (
+			id INTEGER PRIMARY KEY,
+			type TEXT NOT NULL,
+			name TEXT NOT NULL,
+			is_active INTEGER NOT NULL DEFAULT 1,
+			permanently_closed INTEGER NOT NULL DEFAULT 0,
+			UNIQUE(type, name)
+		);
+		INSERT INTO packages (type, name, permanently_closed) VALUES ('plugin', 'zeta-closed', 1);
+		INSERT INTO packages (type, name, permanently_closed) VALUES ('plugin', 'alpha-closed', 1);
+		INSERT INTO packages (type, name, permanently_closed) VALUES ('plugin', 'still-open', 0);
+		INSERT INTO packages (type, name, permanently_closed) VALUES ('theme', 'old-theme', 1);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &app.App{
+		Config: &config.Config{},
+		DB:     database,
+		Logger: slog.Default(),
+	}
+}
+
+func TestAPIClosedPackages_Plugins(t *testing.T) {
+	a := setupClosedTestApp(t)
+	handler := handleAPIClosedPackages(a)
+
+	req := httptest.NewRequest("GET", "/api/packages/wp-plugin/closed", nil)
+	req.SetPathValue("type", "wp-plugin")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type: got %q, want application/json", ct)
+	}
+
+	var slugs []string
+	if err := json.NewDecoder(w.Body).Decode(&slugs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := []string{"alpha-closed", "zeta-closed"}
+	if len(slugs) != len(want) {
+		t.Fatalf("got %v, want %v", slugs, want)
+	}
+	for i, s := range want {
+		if slugs[i] != s {
+			t.Errorf("slug %d: got %q, want %q", i, slugs[i], s)
+		}
+	}
+}
+
+func TestAPIClosedPackages_Themes(t *testing.T) {
+	a := setupClosedTestApp(t)
+	handler := handleAPIClosedPackages(a)
+
+	req := httptest.NewRequest("GET", "/api/packages/wp-theme/closed", nil)
+	req.SetPathValue("type", "wp-theme")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", w.Code)
+	}
+	var slugs []string
+	if err := json.NewDecoder(w.Body).Decode(&slugs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(slugs) != 1 || slugs[0] != "old-theme" {
+		t.Errorf("got %v, want [old-theme]", slugs)
+	}
+}
+
+func TestAPIClosedPackages_BarePrefix(t *testing.T) {
+	a := setupClosedTestApp(t)
+	handler := handleAPIClosedPackages(a)
+
+	req := httptest.NewRequest("GET", "/api/packages/plugin/closed", nil)
+	req.SetPathValue("type", "plugin")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 (bare type without wp- prefix)", w.Code)
+	}
+}
+
+func TestAPIClosedPackages_UnknownType(t *testing.T) {
+	a := setupClosedTestApp(t)
+	handler := handleAPIClosedPackages(a)
+
+	req := httptest.NewRequest("GET", "/api/packages/widget/closed", nil)
+	req.SetPathValue("type", "widget")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("got %d, want 404 for unknown type", w.Code)
+	}
+}
+
+func TestAPIClosedPackages_EmptyResult(t *testing.T) {
+	a := setupClosedTestApp(t)
+	if _, err := a.DB.Exec(`DELETE FROM packages WHERE type = 'theme'`); err != nil {
+		t.Fatal(err)
+	}
+	handler := handleAPIClosedPackages(a)
+
+	req := httptest.NewRequest("GET", "/api/packages/wp-theme/closed", nil)
+	req.SetPathValue("type", "wp-theme")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", w.Code)
+	}
+	// Must be `[]`, not `null`, so consumers can iterate without a nil check.
+	if body := w.Body.String(); body != "[]\n" {
+		t.Errorf("body: got %q, want %q", body, "[]\n")
+	}
+}

--- a/internal/http/api_closed_packages_test.go
+++ b/internal/http/api_closed_packages_test.go
@@ -29,10 +29,11 @@ func setupClosedTestApp(t *testing.T) *app.App {
 			permanently_closed INTEGER NOT NULL DEFAULT 0,
 			UNIQUE(type, name)
 		);
-		INSERT INTO packages (type, name, permanently_closed) VALUES ('plugin', 'zeta-closed', 1);
-		INSERT INTO packages (type, name, permanently_closed) VALUES ('plugin', 'alpha-closed', 1);
-		INSERT INTO packages (type, name, permanently_closed) VALUES ('plugin', 'still-open', 0);
-		INSERT INTO packages (type, name, permanently_closed) VALUES ('theme', 'old-theme', 1);
+		INSERT INTO packages (type, name, is_active, permanently_closed) VALUES ('plugin', 'zeta-permanent', 0, 1);
+		INSERT INTO packages (type, name, is_active, permanently_closed) VALUES ('plugin', 'alpha-permanent', 0, 1);
+		INSERT INTO packages (type, name, is_active, permanently_closed) VALUES ('plugin', 'mango-temporary', 0, 0);
+		INSERT INTO packages (type, name, is_active, permanently_closed) VALUES ('plugin', 'still-open', 1, 0);
+		INSERT INTO packages (type, name, is_active, permanently_closed) VALUES ('theme', 'old-theme', 0, 1);
 	`)
 	if err != nil {
 		t.Fatal(err)
@@ -45,9 +46,18 @@ func setupClosedTestApp(t *testing.T) *app.App {
 	}
 }
 
-func TestAPIClosedPackages_Plugins(t *testing.T) {
+func decodeSlugs(t *testing.T, w *httptest.ResponseRecorder) []string {
+	t.Helper()
+	var slugs []string
+	if err := json.NewDecoder(w.Body).Decode(&slugs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return slugs
+}
+
+func TestAPIClosedPackages_AllPlugins(t *testing.T) {
 	a := setupClosedTestApp(t)
-	handler := handleAPIClosedPackages(a)
+	handler := handleAPIClosedPackages(a, false)
 
 	req := httptest.NewRequest("GET", "/api/packages/wp-plugin/closed", nil)
 	req.SetPathValue("type", "wp-plugin")
@@ -61,11 +71,8 @@ func TestAPIClosedPackages_Plugins(t *testing.T) {
 		t.Errorf("Content-Type: got %q, want application/json", ct)
 	}
 
-	var slugs []string
-	if err := json.NewDecoder(w.Body).Decode(&slugs); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	want := []string{"alpha-closed", "zeta-closed"}
+	slugs := decodeSlugs(t, w)
+	want := []string{"alpha-permanent", "mango-temporary", "zeta-permanent"}
 	if len(slugs) != len(want) {
 		t.Fatalf("got %v, want %v", slugs, want)
 	}
@@ -76,9 +83,34 @@ func TestAPIClosedPackages_Plugins(t *testing.T) {
 	}
 }
 
-func TestAPIClosedPackages_Themes(t *testing.T) {
+func TestAPIClosedPackages_PermanentPlugins(t *testing.T) {
 	a := setupClosedTestApp(t)
-	handler := handleAPIClosedPackages(a)
+	handler := handleAPIClosedPackages(a, true)
+
+	req := httptest.NewRequest("GET", "/api/packages/wp-plugin/closed/permanent", nil)
+	req.SetPathValue("type", "wp-plugin")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", w.Code)
+	}
+
+	slugs := decodeSlugs(t, w)
+	want := []string{"alpha-permanent", "zeta-permanent"}
+	if len(slugs) != len(want) {
+		t.Fatalf("got %v, want %v", slugs, want)
+	}
+	for i, s := range want {
+		if slugs[i] != s {
+			t.Errorf("slug %d: got %q, want %q", i, slugs[i], s)
+		}
+	}
+}
+
+func TestAPIClosedPackages_AllThemes(t *testing.T) {
+	a := setupClosedTestApp(t)
+	handler := handleAPIClosedPackages(a, false)
 
 	req := httptest.NewRequest("GET", "/api/packages/wp-theme/closed", nil)
 	req.SetPathValue("type", "wp-theme")
@@ -88,10 +120,7 @@ func TestAPIClosedPackages_Themes(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("got %d, want 200", w.Code)
 	}
-	var slugs []string
-	if err := json.NewDecoder(w.Body).Decode(&slugs); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	slugs := decodeSlugs(t, w)
 	if len(slugs) != 1 || slugs[0] != "old-theme" {
 		t.Errorf("got %v, want [old-theme]", slugs)
 	}
@@ -99,7 +128,7 @@ func TestAPIClosedPackages_Themes(t *testing.T) {
 
 func TestAPIClosedPackages_BarePrefix(t *testing.T) {
 	a := setupClosedTestApp(t)
-	handler := handleAPIClosedPackages(a)
+	handler := handleAPIClosedPackages(a, false)
 
 	req := httptest.NewRequest("GET", "/api/packages/plugin/closed", nil)
 	req.SetPathValue("type", "plugin")
@@ -113,7 +142,7 @@ func TestAPIClosedPackages_BarePrefix(t *testing.T) {
 
 func TestAPIClosedPackages_UnknownType(t *testing.T) {
 	a := setupClosedTestApp(t)
-	handler := handleAPIClosedPackages(a)
+	handler := handleAPIClosedPackages(a, false)
 
 	req := httptest.NewRequest("GET", "/api/packages/widget/closed", nil)
 	req.SetPathValue("type", "widget")
@@ -130,7 +159,7 @@ func TestAPIClosedPackages_EmptyResult(t *testing.T) {
 	if _, err := a.DB.Exec(`DELETE FROM packages WHERE type = 'theme'`); err != nil {
 		t.Fatal(err)
 	}
-	handler := handleAPIClosedPackages(a)
+	handler := handleAPIClosedPackages(a, false)
 
 	req := httptest.NewRequest("GET", "/api/packages/wp-theme/closed", nil)
 	req.SetPathValue("type", "wp-theme")

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -109,7 +109,8 @@ func NewRouter(a *app.App) http.Handler {
 	apiLimiter := newAPIRateLimiter()
 	route("GET /api/stats", apiLimiter.RateLimit(http.HandlerFunc(handleAPIStats(a))))
 	route("GET /api/stats/packages/{type}/{name}", apiLimiter.RateLimit(http.HandlerFunc(handleAPIMonthlyInstalls(a))))
-	route("GET /api/packages/{type}/closed", apiLimiter.RateLimit(http.HandlerFunc(handleAPIClosedPackages(a))))
+	route("GET /api/packages/{type}/closed", apiLimiter.RateLimit(http.HandlerFunc(handleAPIClosedPackages(a, false))))
+	route("GET /api/packages/{type}/closed/permanent", apiLimiter.RateLimit(http.HandlerFunc(handleAPIClosedPackages(a, true))))
 
 	// Serve Composer repository metadata from DB
 	routeFunc("GET /packages.json", handlePackagesJSON(a))

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -109,6 +109,7 @@ func NewRouter(a *app.App) http.Handler {
 	apiLimiter := newAPIRateLimiter()
 	route("GET /api/stats", apiLimiter.RateLimit(http.HandlerFunc(handleAPIStats(a))))
 	route("GET /api/stats/packages/{type}/{name}", apiLimiter.RateLimit(http.HandlerFunc(handleAPIMonthlyInstalls(a))))
+	route("GET /api/packages/{type}/closed", apiLimiter.RateLimit(http.HandlerFunc(handleAPIClosedPackages(a))))
 
 	// Serve Composer repository metadata from DB
 	routeFunc("GET /packages.json", handlePackagesJSON(a))

--- a/internal/http/templates/docs.html
+++ b/internal/http/templates/docs.html
@@ -216,10 +216,25 @@
 </div>
 
 <h3 class="text-lg font-bold mb-3">GET /api/packages/{type}/closed</h3>
-<p class="text-gray-600 mb-3">Returns a sorted list of slugs for plugins or themes that have been permanently closed on wp.org. The <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">type</code> can be <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">wp-plugin</code> or <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">wp-theme</code>.</p>
+<p class="text-gray-600 mb-3">Returns a sorted list of slugs for plugins or themes that are currently closed on wp.org &mdash; including both temporary and permanent closures. The <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">type</code> can be <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">wp-plugin</code> or <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">wp-theme</code>.</p>
 <div class="flex items-center gap-3 rounded-xl border border-gray-200/60 bg-gray-100/30 px-4 py-2.5 cursor-pointer hover:border-gray-300 transition-colors mb-3" onclick="copyCmd(this,'curl https://wp-packages.org/api/packages/wp-plugin/closed')">
 <span class="text-gray-500 text-sm font-mono select-none shrink-0">$</span>
 <code class="flex-1 text-sm font-mono text-gray-900 truncate">curl https://wp-packages.org/api/packages/wp-plugin/closed</code>
+<button aria-label="Copy to clipboard" class="shrink-0 text-gray-400 hover:text-gray-900 transition-colors cursor-pointer"><svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.75a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"/></svg></button>
+</div>
+<div class="rounded-xl border border-gray-200/60 overflow-hidden mb-8">
+<div class="bg-gray-50/50 px-4 py-2 text-xs text-gray-500 border-b border-gray-200/40">Response</div>
+<pre class="p-4 text-sm font-mono leading-relaxed overflow-x-auto"><code>[
+  <span class="text-green-700">"closed-plugin-slug-a"</span>,
+  <span class="text-green-700">"closed-plugin-slug-b"</span>
+]</code></pre>
+</div>
+
+<h3 class="text-lg font-bold mb-3">GET /api/packages/{type}/closed/permanent</h3>
+<p class="text-gray-600 mb-3">Returns the subset of closed packages that have been flagged as permanently closed on wp.org. Use this endpoint when you only want to surface closures unlikely to ever reopen.</p>
+<div class="flex items-center gap-3 rounded-xl border border-gray-200/60 bg-gray-100/30 px-4 py-2.5 cursor-pointer hover:border-gray-300 transition-colors mb-3" onclick="copyCmd(this,'curl https://wp-packages.org/api/packages/wp-plugin/closed/permanent')">
+<span class="text-gray-500 text-sm font-mono select-none shrink-0">$</span>
+<code class="flex-1 text-sm font-mono text-gray-900 truncate">curl https://wp-packages.org/api/packages/wp-plugin/closed/permanent</code>
 <button aria-label="Copy to clipboard" class="shrink-0 text-gray-400 hover:text-gray-900 transition-colors cursor-pointer"><svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.75a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"/></svg></button>
 </div>
 <div class="rounded-xl border border-gray-200/60 overflow-hidden mb-8">

--- a/internal/http/templates/docs.html
+++ b/internal/http/templates/docs.html
@@ -215,7 +215,22 @@
 ]</code></pre>
 </div>
 
-<p class="text-sm text-gray-500 mb-8">Responses are cached for 5 minutes. Returns <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">404</code> for inactive or unknown packages, and <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">429</code> when rate limited.</p>
+<h3 class="text-lg font-bold mb-3">GET /api/packages/{type}/closed</h3>
+<p class="text-gray-600 mb-3">Returns a sorted list of slugs for plugins or themes that have been permanently closed on wp.org. The <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">type</code> can be <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">wp-plugin</code> or <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">wp-theme</code>.</p>
+<div class="flex items-center gap-3 rounded-xl border border-gray-200/60 bg-gray-100/30 px-4 py-2.5 cursor-pointer hover:border-gray-300 transition-colors mb-3" onclick="copyCmd(this,'curl https://wp-packages.org/api/packages/wp-plugin/closed')">
+<span class="text-gray-500 text-sm font-mono select-none shrink-0">$</span>
+<code class="flex-1 text-sm font-mono text-gray-900 truncate">curl https://wp-packages.org/api/packages/wp-plugin/closed</code>
+<button aria-label="Copy to clipboard" class="shrink-0 text-gray-400 hover:text-gray-900 transition-colors cursor-pointer"><svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.75a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"/></svg></button>
+</div>
+<div class="rounded-xl border border-gray-200/60 overflow-hidden mb-8">
+<div class="bg-gray-50/50 px-4 py-2 text-xs text-gray-500 border-b border-gray-200/40">Response</div>
+<pre class="p-4 text-sm font-mono leading-relaxed overflow-x-auto"><code>[
+  <span class="text-green-700">"closed-plugin-slug-a"</span>,
+  <span class="text-green-700">"closed-plugin-slug-b"</span>
+]</code></pre>
+</div>
+
+<p class="text-sm text-gray-500 mb-8">Stats responses are cached for 5 minutes; the closed-packages list is cached for 1 hour. Returns <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">404</code> for inactive or unknown packages, and <code class="text-xs font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200/40">429</code> when rate limited.</p>
 
 </div>
 <aside class="hidden md:block">


### PR DESCRIPTION
## Summary
- New endpoints returning a sorted JSON array of slugs for closed packages:
  - `GET /api/packages/{type}/closed` — all closed packages (`is_active = 0`, includes temporary + permanent closures)
  - `GET /api/packages/{type}/closed/permanent` — subset flagged `permanently_closed = 1`
- `{type}` accepts `wp-plugin`/`wp-theme` (or bare `plugin`/`theme`) to match the existing `/api/stats/packages/{type}/{name}` convention.
- Cached for 1 hour (`Cache-Control: public, max-age=3600`); shares the existing per-IP API rate limiter; gzip handled at the Caddy layer.
- Documented in the API section of `/docs`.

For context, today's prod numbers: ~51k closed plugins (~9.5k of those permanent) and ~16k closed themes. Wire size lands well under a megabyte gzipped.

Motivated by tools like [wp-org-closed-plugin](https://github.com/typisttech/wp-org-closed-plugin) that today hit wp.org once per package in `composer.lock` — they can now fetch a single list instead. Use `/closed` to surface anything wp.org has pulled, or `/closed/permanent` if you only want the stable subset that's unlikely to come back.

Closes #100