### PR TITLE
Post closure report gist when a vendor has 2+ closures

### DIFF
--- a/cmd/wppackages/cmd/check_status.go
+++ b/cmd/wppackages/cmd/check_status.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/roots/wp-packages/internal/packages"
+	"github.com/roots/wp-packages/internal/reports"
 	"github.com/roots/wp-packages/internal/wporg"
 )
 
@@ -142,6 +143,13 @@ func runCheckStatus(cmd *cobra.Command, args []string) error {
 		"reactivated", reactivated.Load(),
 		"failed", failed.Load(),
 	)
+
+	if gistURL, err := reports.PostClosureReport(ctx, application.DB, runID, started, application.Config.GitHubToken); err != nil {
+		application.Logger.Warn("failed to post closure gist", "error", err)
+	} else if gistURL != "" {
+		application.Logger.Info("posted closure gist", "url", gistURL)
+	}
+
 	return runErr
 }
 

--- a/deploy/ansible/group_vars/production/vault.example.yml
+++ b/deploy/ansible/group_vars/production/vault.example.yml
@@ -10,6 +10,7 @@
 # - vault_r2_cdn_bucket
 # - vault_sentry_dsn
 # - vault_discord_webhook_url
+# - vault_github_token
 
 vault_r2_access_key_id: "REPLACE_ME"
 vault_r2_secret_access_key: "REPLACE_ME"
@@ -19,6 +20,7 @@ vault_r2_cdn_bucket: "REPLACE_ME"
 vault_r2_litestream_bucket: "REPLACE_ME"
 vault_sentry_dsn: "REPLACE_ME"
 vault_discord_webhook_url: "REPLACE_ME"
+vault_github_token: "REPLACE_ME"
 vault_ssl_certificate: |
   -----BEGIN CERTIFICATE-----
   REPLACE_ME

--- a/deploy/ansible/roles/app/templates/env.j2
+++ b/deploy/ansible/roles/app/templates/env.j2
@@ -22,3 +22,4 @@ LITESTREAM_BUCKET={{ vault_r2_litestream_bucket }}
 SENTRY_DSN={{ vault_sentry_dsn }}
 
 DISCORD_WEBHOOK_URL={{ vault_discord_webhook_url | default('') }}
+GITHUB_TOKEN={{ vault_github_token | default('') }}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,8 @@ type Config struct {
 	Debug    bool   `yaml:"debug"`
 	LogLevel string `yaml:"log_level"`
 
-	SentryDSN string `yaml:"sentry_dsn"`
+	SentryDSN   string `yaml:"sentry_dsn"`
+	GitHubToken string `yaml:"github_token"`
 
 	DB         DBConfig         `yaml:"db"`
 	Server     ServerConfig     `yaml:"server"`
@@ -124,6 +125,9 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("SENTRY_DSN"); v != "" {
 		cfg.SentryDSN = v
+	}
+	if v := os.Getenv("GITHUB_TOKEN"); v != "" {
+		cfg.GitHubToken = v
 	}
 	if v := os.Getenv("DB_PATH"); v != "" {
 		cfg.DB.Path = v

--- a/internal/reports/closure_gist.go
+++ b/internal/reports/closure_gist.go
@@ -1,0 +1,169 @@
+// Package reports builds and publishes operational reports about package
+// activity, such as closure summaries posted to GitHub Gists.
+package reports
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ClosureGistVendorMin is the minimum number of plugin closures from a single
+// vendor (author) in a status check run before a report gist is posted.
+const ClosureGistVendorMin = 2
+
+var htmlTagRE = regexp.MustCompile(`<[^>]*>`)
+
+type closure struct {
+	Slug   string
+	Author string
+}
+
+type vendorGroup struct {
+	Name  string
+	Items []closure
+}
+
+// PostClosureReport posts a private gist summarising plugin closures from a
+// status check run, grouping plugins under any vendor (author) that owns
+// more than one closure. Returns the gist URL, or "" if no gist was posted
+// (token missing, too few closures, or no vendor with >1 closure).
+func PostClosureReport(ctx context.Context, db *sql.DB, runID int64, runStarted time.Time, token string) (string, error) {
+	if token == "" {
+		return "", nil
+	}
+
+	closures, err := loadClosures(ctx, db, runID)
+	if err != nil {
+		return "", err
+	}
+
+	multi := groupByVendor(closures)
+	if len(multi) == 0 {
+		return "", nil
+	}
+
+	md := renderMarkdown(runStarted, multi)
+	return postGist(ctx, token, runStarted, md)
+}
+
+func loadClosures(ctx context.Context, db *sql.DB, runID int64) ([]closure, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT scc.package_name, COALESCE(p.author, '')
+		FROM status_check_changes scc
+		LEFT JOIN packages p ON p.type = scc.package_type AND p.name = scc.package_name
+		WHERE scc.status_check_id = ?
+		  AND scc.package_type = 'plugin'
+		  AND scc.action IN ('deactivated','tombstoned')`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("querying closures: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []closure
+	for rows.Next() {
+		var c closure
+		if err := rows.Scan(&c.Slug, &c.Author); err != nil {
+			return nil, err
+		}
+		c.Author = strings.TrimSpace(htmlTagRE.ReplaceAllString(c.Author, ""))
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+func groupByVendor(closures []closure) []vendorGroup {
+	groups := map[string][]closure{}
+	displayName := map[string]string{}
+	for _, c := range closures {
+		key := strings.ToLower(c.Author)
+		groups[key] = append(groups[key], c)
+		if _, ok := displayName[key]; !ok && c.Author != "" {
+			displayName[key] = c.Author
+		}
+	}
+
+	var multi []vendorGroup
+	for key, items := range groups {
+		if key != "" && len(items) >= ClosureGistVendorMin {
+			multi = append(multi, vendorGroup{Name: displayName[key], Items: items})
+		}
+	}
+
+	sort.Slice(multi, func(i, j int) bool {
+		if len(multi[i].Items) != len(multi[j].Items) {
+			return len(multi[i].Items) > len(multi[j].Items)
+		}
+		return multi[i].Name < multi[j].Name
+	})
+	for i := range multi {
+		sort.Slice(multi[i].Items, func(a, b int) bool { return multi[i].Items[a].Slug < multi[i].Items[b].Slug })
+	}
+	return multi
+}
+
+func renderMarkdown(runStarted time.Time, multi []vendorGroup) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "WordPress.org plugins closed on %s\n\n", runStarted.UTC().Format(time.RFC3339))
+
+	for _, v := range multi {
+		fmt.Fprintf(&b, "## %s\n\n", v.Name)
+		b.WriteString("| Plugin slug | WordPress.org URL | Notes |\n")
+		b.WriteString("| --- | --- | --- |\n")
+		for _, it := range v.Items {
+			fmt.Fprintf(&b, "| `%s` | https://wordpress.org/plugins/%s/ | |\n", it.Slug, it.Slug)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func postGist(ctx context.Context, token string, runStarted time.Time, content string) (string, error) {
+	filename := fmt.Sprintf("wp-plugins-closed-%s.md", runStarted.UTC().Format("2006-01-02"))
+	payload, err := json.Marshal(map[string]any{
+		"description": fmt.Sprintf("WordPress.org plugins closed on %s", runStarted.UTC().Format(time.RFC3339)),
+		"public":      false,
+		"files": map[string]any{
+			filename: map[string]string{"content": content},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.github.com/gists", bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "wp-packages/1.0 (+https://wp-packages.org)")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("posting gist: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("gist API %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var result struct {
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	return result.HTMLURL, nil
+}


### PR DESCRIPTION
## Summary

- After each `check-status` run, group the run's deactivated/tombstoned plugins by their wp.org `author` field. If any vendor has 2+ closures, render a markdown report (vendor as `## H2`, table of plugin slugs + wp.org URLs) and post it as a **private** gist via the GitHub API.
- Wires `GITHUB_TOKEN` (PAT, `gist` scope only) through config, env.j2, and the production vault example.

Gists are initially private while we test the heuristic and the output. Once we're happy with what's getting flagged, we'll likely swap this for a different reporting channel (e.g. a public dashboard, Discord, or just public gists) — see discussion below.

## Notes

- Trigger: any single author with `>= 2` closures in one run. No total-count floor.
- Vendor is taken from the `packages.author` column (HTML stripped, lowercased for grouping). This is lossy for plugins with multiple contributors — we only store the byline today. Good enough for the obvious "one shop got swept" pattern; richer matching via wp.org `contributors` can come later.
- Themes are excluded — query restricts to `package_type = 'plugin'`.
- No new DB writes; the report reads `status_check_changes` for the current run.

## Refs

- https://x.com/retlehs/status/2049620638655008800
- https://x.com/retlehs/status/2048918058207793464
- https://gist.github.com/retlehs/1db73cb0bc1d7ed3f663dac20a5e8a9d
- https://gist.github.com/retlehs/8a9f1644fd9fce81e20676bb97903733

🤖 Generated with [Claude Code](https://claude.com/claude-code)