### PR TITLE
Add cleanup-r2-orphans command for bulk R2 deletion

### DIFF
--- a/cmd/wppackages/cmd/cleanup_r2_orphans.go
+++ b/cmd/wppackages/cmd/cleanup_r2_orphans.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/roots/wp-packages/internal/deploy"
+)
+
+var cleanupR2OrphansCmd = &cobra.Command{
+	Use:   "cleanup-r2-orphans",
+	Short: "Bulk-delete R2 files for deactivated packages (one-off historical sweep)",
+	Long: `Deletes R2 files for all packages where is_active=0 AND deployed_hash IS NOT NULL,
+using the S3 DeleteObjects batch API (up to 1000 keys per request) parallelized
+across cfg.R2.Concurrency workers.
+
+Intended for one-off cleanup of historical orphans. The regular per-deploy path
+in SyncToR2 uses a serial loop, which is fine for the small number of
+deactivations per 5-min pipeline cycle but far too slow for an initial backfill.
+
+Safe to interrupt and re-run — successfully-cleaned packages have their
+deployed_hash cleared, so a subsequent run only picks up what's left.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, err := deploy.BulkDeleteDeactivated(
+			cmd.Context(), application.DB, application.Config.R2, application.Logger,
+		)
+		if err != nil {
+			return err
+		}
+		application.Logger.Info("cleanup-r2-orphans complete",
+			"packages", result.Packages,
+			"keys_deleted", result.KeysDeleted,
+			"keys_failed", result.KeysFailed)
+		return nil
+	},
+}
+
+func init() {
+	appCommand(cleanupR2OrphansCmd)
+	rootCmd.AddCommand(cleanupR2OrphansCmd)
+}

--- a/internal/deploy/cleanup.go
+++ b/internal/deploy/cleanup.go
@@ -1,0 +1,199 @@
+package deploy
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/roots/wp-packages/internal/composer"
+	"github.com/roots/wp-packages/internal/config"
+	"github.com/roots/wp-packages/internal/packages"
+)
+
+// r2DeleteBatchSize is the max number of keys per S3 DeleteObjects call (S3/R2 limit is 1000).
+const r2DeleteBatchSize = 1000
+
+// BulkDeleteResult holds stats from a bulk cleanup run.
+type BulkDeleteResult struct {
+	Packages    int
+	KeysDeleted int
+	KeysFailed  int
+}
+
+// BulkDeleteDeactivated deletes R2 files for all packages where
+// is_active=0 AND deployed_hash IS NOT NULL, using S3 DeleteObjects
+// (batches of up to 1000 keys) parallelized across cfg.Concurrency workers.
+// After each batch succeeds, deployed_hash is cleared for the packages whose
+// keys all succeeded in that batch.
+//
+// Intended for one-off cleanup of historical orphans (the regular per-deploy
+// path in SyncToR2 uses a serial loop which is fine for the small number of
+// deactivations per 5-min pipeline cycle).
+func BulkDeleteDeactivated(ctx context.Context, db *sql.DB, cfg config.R2Config, logger *slog.Logger) (*BulkDeleteResult, error) {
+	deactivated, err := packages.GetDeactivatedDeployedPackages(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("querying deactivated packages: %w", err)
+	}
+	if len(deactivated) == 0 {
+		return &BulkDeleteResult{}, nil
+	}
+
+	client := newS3Client(cfg)
+
+	type keyRef struct {
+		PkgID int64
+		Key   string
+	}
+	keys := make([]keyRef, 0, len(deactivated)*2)
+	pkgKeyCount := make(map[int64]int, len(deactivated))
+	for _, p := range deactivated {
+		for _, k := range composer.ObjectKeys(p.Type, p.Name) {
+			keys = append(keys, keyRef{PkgID: p.ID, Key: k})
+			pkgKeyCount[p.ID]++
+		}
+	}
+
+	logger.Info("bulk delete starting",
+		"packages", len(deactivated), "keys", len(keys), "concurrency", cfg.Concurrency)
+
+	concurrency := cfg.Concurrency
+	if concurrency <= 0 {
+		concurrency = 50
+	}
+
+	var (
+		keysDeleted atomic.Int64
+		keysFailed  atomic.Int64
+		mu          sync.Mutex
+		pkgFailed   = make(map[int64]int)
+	)
+
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+
+	for start := 0; start < len(keys); start += r2DeleteBatchSize {
+		end := start + r2DeleteBatchSize
+		if end > len(keys) {
+			end = len(keys)
+		}
+		batch := keys[start:end]
+		batchStart := start
+		g.Go(func() error {
+			objs := make([]s3types.ObjectIdentifier, len(batch))
+			for i, k := range batch {
+				objs[i] = s3types.ObjectIdentifier{Key: aws.String(k.Key)}
+			}
+			resp, err := client.DeleteObjects(gCtx, &s3.DeleteObjectsInput{
+				Bucket: aws.String(cfg.Bucket),
+				Delete: &s3types.Delete{Objects: objs, Quiet: aws.Bool(true)},
+			})
+			if err != nil {
+				logger.Warn("bulk delete: batch failed", "batch_start", batchStart, "size", len(batch), "error", err)
+				mu.Lock()
+				for _, k := range batch {
+					pkgFailed[k.PkgID]++
+				}
+				mu.Unlock()
+				keysFailed.Add(int64(len(batch)))
+				return nil
+			}
+
+			failedKeys := make(map[string]struct{}, len(resp.Errors))
+			for _, e := range resp.Errors {
+				if e.Key == nil {
+					continue
+				}
+				failedKeys[*e.Key] = struct{}{}
+				logger.Warn("bulk delete: key failed",
+					"key", *e.Key,
+					"code", aws.ToString(e.Code),
+					"msg", aws.ToString(e.Message))
+			}
+
+			batchSuccessIDs := make([]int64, 0, len(batch))
+			for _, k := range batch {
+				if _, bad := failedKeys[k.Key]; bad {
+					mu.Lock()
+					pkgFailed[k.PkgID]++
+					mu.Unlock()
+					keysFailed.Add(1)
+					continue
+				}
+				batchSuccessIDs = append(batchSuccessIDs, k.PkgID)
+				keysDeleted.Add(1)
+			}
+
+			// Best-effort: clear deployed_hash for packages whose every key in
+			// THIS batch succeeded. A package may have keys across multiple
+			// batches; we re-check overall success at the end and re-clear if
+			// needed (idempotent).
+			if err := clearDeployedHash(gCtx, db, batchSuccessIDs); err != nil {
+				logger.Warn("bulk delete: failed to clear deployed_hash for batch", "error", err)
+			}
+
+			done := keysDeleted.Load() + keysFailed.Load()
+			logger.Info("bulk delete: batch done",
+				"deleted_so_far", keysDeleted.Load(),
+				"failed_so_far", keysFailed.Load(),
+				"progress", fmt.Sprintf("%d/%d", done, len(keys)))
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("bulk delete: %w", err)
+	}
+
+	// Final pass: any package with zero failed keys gets deployed_hash cleared.
+	// (The per-batch clear above handles the common case; this covers packages
+	// whose keys spanned multiple batches.)
+	allOKIDs := make([]int64, 0, len(deactivated))
+	for _, p := range deactivated {
+		if pkgFailed[p.ID] == 0 {
+			allOKIDs = append(allOKIDs, p.ID)
+		}
+	}
+	if err := clearDeployedHash(ctx, db, allOKIDs); err != nil {
+		return nil, fmt.Errorf("bulk delete: final clear deployed_hash: %w", err)
+	}
+
+	return &BulkDeleteResult{
+		Packages:    len(deactivated),
+		KeysDeleted: int(keysDeleted.Load()),
+		KeysFailed:  int(keysFailed.Load()),
+	}, nil
+}
+
+// clearDeployedHash sets deployed_hash = NULL for the given package IDs.
+// Chunks the IN clause to stay under SQLite's parameter limit.
+func clearDeployedHash(ctx context.Context, db *sql.DB, ids []int64) error {
+	const chunk = 500
+	for start := 0; start < len(ids); start += chunk {
+		end := start + chunk
+		if end > len(ids) {
+			end = len(ids)
+		}
+		slice := ids[start:end]
+		placeholders := strings.Repeat("?,", len(slice))
+		placeholders = placeholders[:len(placeholders)-1]
+		args := make([]any, len(slice))
+		for i, id := range slice {
+			args[i] = id
+		}
+		q := fmt.Sprintf(`UPDATE packages SET deployed_hash = NULL WHERE id IN (%s)`, placeholders)
+		if _, err := db.ExecContext(ctx, q, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Follow-up to #108. The band-aid added there uses a serial loop in `SyncToR2()` to delete R2 files for deactivated packages — fine for the handful of deactivations per 5-min pipeline cycle, but far too slow for the one-time backfill needed after #108 ships.

The backfill needs to clear ~67k packages × 2 keys = ~135k DeleteObject calls. At ~135ms per call, the serial loop projects to **~5 hours** and blocks the pipeline (oneshot service skips timer ticks while running). Confirmed empirically on prod: ~3.7 packages/sec.

This PR adds `wppackages cleanup-r2-orphans`, a one-off CLI command that uses the S3 `DeleteObjects` batch API (up to 1000 keys per request) parallelized across `cfg.R2.Concurrency` workers. ~135 batches at ~50-wide concurrency should finish in seconds, not hours.

## What it does

`internal/deploy/cleanup.go` — new `BulkDeleteDeactivated()`:

- Queries `is_active = 0 AND deployed_hash IS NOT NULL` (same predicate as `SyncToR2`)
- Builds the flat list of `(package_id, key)` pairs
- Splits into 1000-key batches, runs `DeleteObjects` across an `errgroup` capped at `cfg.R2.Concurrency`
- Tracks per-key failures from the `DeleteObjectsOutput.Errors` field
- Clears `deployed_hash` per-batch (best effort) and again in a final pass for packages whose keys spanned multiple batches
- Safe to interrupt and re-run — successfully-cleaned packages have their `deployed_hash` cleared, so a subsequent run only picks up what's left

`cmd/wppackages/cmd/cleanup_r2_orphans.go` — thin Cobra wrapper that calls `BulkDeleteDeactivated()` and logs the result.

## How to run (one-time, on prod)

```sh
# Stop the running pipeline + timer so they don't fight the bulk cleanup
sudo systemctl stop wppackages-pipeline.service
sudo systemctl stop wppackages-pipeline.timer

# Bulk cleanup
/srv/wp-packages/current/wppackages cleanup-r2-orphans --db /srv/wp-packages/shared/storage/wppackages.db

# Resume normal pipeline operation
sudo systemctl start wppackages-pipeline.timer
```

After this, the regular per-deploy serial loop in `SyncToR2` is sufficient — only a few packages get deactivated per cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
