### PR TITLE
Honor wp.org stable versions

### DIFF
--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -67,7 +67,7 @@ type Package struct {
 }
 
 // NormalizeAndStoreVersions normalizes raw versions and serializes to VersionsJSON.
-// It also sets CurrentVersion to the highest available version.
+// It also sets CurrentVersion to the highest published version.
 // Returns the number of valid versions.
 func (p *Package) NormalizeAndStoreVersions() (int, error) {
 	if p.RawVersions == nil {
@@ -76,6 +76,9 @@ func (p *Package) NormalizeAndStoreVersions() (int, error) {
 	}
 
 	normalized := version.NormalizeVersions(p.RawVersions)
+	if p.WporgVersion != nil {
+		normalized = version.FilterNewerThan(normalized, *p.WporgVersion)
+	}
 
 	data, err := json.Marshal(normalized)
 	if err != nil {

--- a/internal/packages/package_test.go
+++ b/internal/packages/package_test.go
@@ -3,6 +3,7 @@ package packages
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -156,6 +157,41 @@ func TestUpsertPackage(t *testing.T) {
 	_ = database.QueryRow("SELECT downloads FROM packages WHERE name='akismet'").Scan(&downloads)
 	if downloads != 2000 {
 		t.Errorf("downloads = %d, want 2000", downloads)
+	}
+}
+
+func TestNormalizeAndStoreVersionsUsesWporgVersion(t *testing.T) {
+	wporgVersion := "10.7.0"
+	pkg := &Package{
+		WporgVersion: &wporgVersion,
+		RawVersions: map[string]string{
+			"10.6.0":    "https://example.com/10.6.0.zip",
+			"10.7.0":    "https://example.com/10.7.0.zip",
+			"10.8.0":    "https://example.com/10.8.0.zip",
+			"dev-trunk": "https://example.com/trunk.zip",
+		},
+	}
+
+	count, err := pkg.NormalizeAndStoreVersions()
+	if err != nil {
+		t.Fatalf("normalizing versions: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("NormalizeAndStoreVersions returned %d entries, want 3", count)
+	}
+	if pkg.CurrentVersion == nil || *pkg.CurrentVersion != "10.7.0" {
+		t.Fatalf("CurrentVersion = %v, want 10.7.0", pkg.CurrentVersion)
+	}
+
+	var versions map[string]string
+	if err := json.Unmarshal([]byte(pkg.VersionsJSON), &versions); err != nil {
+		t.Fatalf("unmarshaling versions: %v", err)
+	}
+	if _, ok := versions["10.8.0"]; ok {
+		t.Fatal("10.8.0 should have been filtered out")
+	}
+	if versions["10.7.0"] == "" {
+		t.Fatal("10.7.0 should remain")
 	}
 }
 

--- a/internal/version/normalize.go
+++ b/internal/version/normalize.go
@@ -57,6 +57,23 @@ func NormalizeVersions(versions map[string]string) map[string]string {
 	return result
 }
 
+// FilterNewerThan removes tagged versions newer than maxVersion. dev-trunk is
+// preserved; an invalid maxVersion disables filtering.
+func FilterNewerThan(versions map[string]string, maxVersion string) map[string]string {
+	max := Normalize(maxVersion)
+	if max == "" || max == "dev-trunk" {
+		return versions
+	}
+
+	result := make(map[string]string, len(versions))
+	for v, url := range versions {
+		if v == "dev-trunk" || Compare(v, max) <= 0 {
+			result[v] = url
+		}
+	}
+	return result
+}
+
 // Compare compares two version strings numerically by segment.
 // Pre-release suffixes (e.g. -beta1) are compared lexically when
 // numeric segments are equal. Returns -1, 0, or 1.

--- a/internal/version/normalize_test.go
+++ b/internal/version/normalize_test.go
@@ -155,6 +155,34 @@ func TestNormalizeVersions(t *testing.T) {
 	}
 }
 
+func TestFilterNewerThan(t *testing.T) {
+	versions := map[string]string{
+		"10.6.0":    "https://example.com/10.6.0.zip",
+		"10.7.0":    "https://example.com/10.7.0.zip",
+		"10.8.0":    "https://example.com/10.8.0.zip",
+		"dev-trunk": "https://example.com/trunk.zip",
+	}
+
+	got := FilterNewerThan(versions, "10.7.0")
+	if len(got) != 3 {
+		t.Fatalf("FilterNewerThan returned %d entries, want 3", len(got))
+	}
+	if _, ok := got["10.8.0"]; ok {
+		t.Fatal("10.8.0 should have been filtered out")
+	}
+	if got["10.7.0"] == "" {
+		t.Fatal("10.7.0 should remain")
+	}
+	if got["dev-trunk"] == "" {
+		t.Fatal("dev-trunk should remain")
+	}
+
+	unfiltered := FilterNewerThan(versions, "not-a-version")
+	if len(unfiltered) != len(versions) {
+		t.Fatalf("invalid ceiling should not filter versions")
+	}
+}
+
 func TestIsStable(t *testing.T) {
 	stable := []string{"1.0", "1.0.0", "10.6.2", "5.3.2"}
 	for _, v := range stable {


### PR DESCRIPTION
It normalizes wp.org versions, drops tagged releases newer than the published stable version from wp.org API, but keeping dev-trunk available.


Fixes #111
Fixes #78

Tests:
- `docker run --rm -u "$(id -u):$(id -g)" -e GOCACHE=/tmp/go-build -e GOMODCACHE=/tmp/go-mod -v "$PWD":/src -w /src golang:1.26.1 go test ./...`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.37 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5
