### PR TITLE
Keep above-stable pre-release tags

### DIFF
--- a/internal/version/normalize.go
+++ b/internal/version/normalize.go
@@ -57,8 +57,13 @@ func NormalizeVersions(versions map[string]string) map[string]string {
 	return result
 }
 
-// FilterNewerThan removes tagged versions newer than maxVersion. dev-trunk is
-// preserved; an invalid maxVersion disables filtering.
+// FilterNewerThan removes stable tagged releases newer than maxVersion. These are
+// typically tags pushed to SVN ahead of the published Stable Tag, which Composer
+// would otherwise resolve as the latest stable release. Pre-release tags newer
+// than maxVersion (e.g. a 4.0.0-beta1 while stable is 3.x) are preserved: Composer
+// never auto-selects them for a normal require, so they only reach users who
+// explicitly opt in to that stability. dev-trunk is always preserved; an invalid
+// maxVersion disables filtering.
 func FilterNewerThan(versions map[string]string, maxVersion string) map[string]string {
 	max := Normalize(maxVersion)
 	if max == "" || max == "dev-trunk" {
@@ -67,7 +72,7 @@ func FilterNewerThan(versions map[string]string, maxVersion string) map[string]s
 
 	result := make(map[string]string, len(versions))
 	for v, url := range versions {
-		if v == "dev-trunk" || Compare(v, max) <= 0 {
+		if v == "dev-trunk" || !IsStable(v) || Compare(v, max) <= 0 {
 			result[v] = url
 		}
 	}

--- a/internal/version/normalize_test.go
+++ b/internal/version/normalize_test.go
@@ -183,6 +183,37 @@ func TestFilterNewerThan(t *testing.T) {
 	}
 }
 
+// TestFilterNewerThanKeepsPreReleases verifies that pre-release tags newer than
+// the stable ceiling are retained (Composer won't auto-select them), while stable
+// tags newer than the ceiling are still dropped.
+func TestFilterNewerThanKeepsPreReleases(t *testing.T) {
+	versions := map[string]string{
+		"3.1.3":       "https://example.com/3.1.3.zip",       // stable ceiling
+		"4.0.0-beta1": "https://example.com/4.0.0-beta1.zip", // newer pre-release — keep
+		"4.0.0":       "https://example.com/4.0.0.zip",       // newer stable — drop
+		"2.3.1-beta2": "https://example.com/2.3.1-beta2.zip", // older pre-release — keep
+		"dev-trunk":   "https://example.com/trunk.zip",
+	}
+
+	got := FilterNewerThan(versions, "3.1.3")
+
+	if _, ok := got["4.0.0"]; ok {
+		t.Error("4.0.0 (stable above ceiling) should have been filtered out")
+	}
+	if _, ok := got["4.0.0-beta1"]; !ok {
+		t.Error("4.0.0-beta1 (pre-release above ceiling) should be retained")
+	}
+	if _, ok := got["2.3.1-beta2"]; !ok {
+		t.Error("2.3.1-beta2 (pre-release below ceiling) should be retained")
+	}
+	if _, ok := got["3.1.3"]; !ok {
+		t.Error("3.1.3 (the ceiling) should be retained")
+	}
+	if _, ok := got["dev-trunk"]; !ok {
+		t.Error("dev-trunk should be retained")
+	}
+}
+
 func TestIsStable(t *testing.T) {
 	stable := []string{"1.0", "1.0.0", "10.6.2", "5.3.2"}
 	for _, v := range stable {


### PR DESCRIPTION
## Problem

#112 fixed phantom stable releases (#78, #111) by dropping every tagged version newer than the wp.org Stable Tag. That filter is too broad: it also drops pre-release tags above stable. A plugin that tags `4.0.0-beta1` while its Stable Tag is still `3.x` no longer exposes that beta as an installable Composer version — confirmed against `addy-autocomplete-woocommerce`.

## Why pre-releases are different

The phantom-release problem only applies to stable tags: Composer resolves a normal `require` to the highest stable version, so a `4.0.0` tag ahead of the published stable would get auto-selected and break installs. Pre-releases never have that problem — Composer won't select a `4.0.0-beta1` unless the user explicitly opts in (a beta constraint plus `minimum-stability`). So keeping above-stable pre-releases restores beta installs without reintroducing #78/#111.

## Change

`FilterNewerThan` now drops a version only when it's both newer than the ceiling **and** stable. Above-stable pre-releases and `dev-trunk` are retained. One added condition (`!IsStable(v)`), an updated doc comment, and a test covering an above-stable beta being kept while an above-stable stable tag is dropped.

Existing `versions_json` reflects the new behavior as each package re-syncs (or on `update --force`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)