### PR TITLE
Add sorting to mass closure history page

### DIFF
--- a/internal/http/closures.go
+++ b/internal/http/closures.go
@@ -15,14 +15,24 @@ import (
 
 const closuresPerPage = 50
 
+// closureSort normalizes the sort query param to a whitelisted value:
+// "closures" (most plugins closed first) or "recent" (default).
+func closureSort(r *http.Request) string {
+	if r.URL.Query().Get("sort") == "closures" {
+		return "closures"
+	}
+	return "recent"
+}
+
 func handleClosures(a *app.App, tmpl *templateSet) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
 		if page < 1 {
 			page = 1
 		}
+		sort := closureSort(r)
 
-		events, total, err := packages.GetClosureEvents(r.Context(), a.DB, page, closuresPerPage)
+		events, total, err := packages.GetClosureEvents(r.Context(), a.DB, sort, page, closuresPerPage)
 		if err != nil {
 			a.Logger.Error("querying closure events", "error", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -34,6 +44,7 @@ func handleClosures(a *app.App, tmpl *templateSet) http.HandlerFunc {
 			"CDNURL":     a.Config.R2.CDNPublicURL,
 			"OGImage":    ogImageURL(a.Config, "social/closures.png"),
 			"Events":     events,
+			"Sort":       sort,
 			"Page":       page,
 			"PerPage":    closuresPerPage,
 			"TotalPages": totalPages(total, closuresPerPage),
@@ -82,8 +93,9 @@ func handleAPIClosures(a *app.App) http.HandlerFunc {
 		if page < 1 {
 			page = 1
 		}
+		sort := closureSort(r)
 
-		events, total, err := packages.GetClosureEvents(r.Context(), a.DB, page, closuresPerPage)
+		events, total, err := packages.GetClosureEvents(r.Context(), a.DB, sort, page, closuresPerPage)
 		if err != nil {
 			a.Logger.Error("api: querying closure events", "error", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -94,6 +106,7 @@ func handleAPIClosures(a *app.App) http.HandlerFunc {
 		w.Header().Set("Cache-Control", "public, max-age=3600")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"events":            formatEvents(events),
+			"sort":              sort,
 			"page":              page,
 			"per_page":          closuresPerPage,
 			"total":             total,
@@ -229,7 +242,7 @@ func handleClosuresFeed(a *app.App) http.HandlerFunc {
 		cache.mu.RUnlock()
 
 		if !fresh {
-			events, _, err := packages.GetClosureEvents(r.Context(), a.DB, 1, closuresPerPage)
+			events, _, err := packages.GetClosureEvents(r.Context(), a.DB, "recent", 1, closuresPerPage)
 			if err != nil {
 				a.Logger.Error("querying closure events for feed", "error", err)
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/http/markdown.go
+++ b/internal/http/markdown.go
@@ -622,7 +622,8 @@ func handleClosuresMD(a *app.App, appURL string) http.HandlerFunc {
 		if page < 1 {
 			page = 1
 		}
-		events, total, err := packages.GetClosureEvents(r.Context(), a.DB, page, closuresPerPage)
+		sort := closureSort(r)
+		events, total, err := packages.GetClosureEvents(r.Context(), a.DB, sort, page, closuresPerPage)
 		if err != nil {
 			a.Logger.Error("querying closure events for markdown", "error", err)
 			captureError(r, err)
@@ -631,12 +632,12 @@ func handleClosuresMD(a *app.App, appURL string) http.HandlerFunc {
 		}
 		cleanQuery := extractContentQuery("GET /closures", r.URL.RawQuery)
 		setPaginationLinkHeader(w, page, total, closuresPerPage, "/closures.md", appURL, cleanQuery)
-		body := renderClosuresMarkdown(events, total, page, appURL, cleanQuery)
+		body := renderClosuresMarkdown(events, total, page, sort, appURL, cleanQuery)
 		writeMarkdown(w, body, "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400")
 	}
 }
 
-func renderClosuresMarkdown(events []packages.ClosureEvent, total, page int, appURL, rawQuery string) string {
+func renderClosuresMarkdown(events []packages.ClosureEvent, total, page int, sort, appURL, rawQuery string) string {
 	var b strings.Builder
 	b.WriteString("# WordPress.org Mass Closures\n\n")
 	b.WriteString("History of WordPress.org plugin vendors with multiple closures within a 24-hour rolling window.\n\n")
@@ -645,7 +646,11 @@ func renderClosuresMarkdown(events []packages.ClosureEvent, total, page int, app
 		return b.String()
 	}
 	tp := totalPages(total, closuresPerPage)
-	fmt.Fprintf(&b, "## Events (page %d of %d)\n\n", page, tp)
+	sortLabel := "most recent"
+	if sort == "closures" {
+		sortLabel = "number of closures"
+	}
+	fmt.Fprintf(&b, "## Events (page %d of %d, sorted by %s)\n\n", page, tp, sortLabel)
 	b.WriteString("| Vendor | Plugins closed | Detected |\n")
 	b.WriteString("| --- | ---: | --- |\n")
 	for _, e := range events {

--- a/internal/http/negotiate.go
+++ b/internal/http/negotiate.go
@@ -69,7 +69,7 @@ var staticExtensions = map[string]struct{}{
 var mdContentParams = map[string][]string{
 	"GET /{$}":      {"search", "type", "sort", "page"},
 	"GET /untagged": {"filter", "search", "author", "sort", "page"},
-	"GET /closures": {"page"},
+	"GET /closures": {"sort", "page"},
 }
 
 // extractContentQuery returns the URL-encoded subset of rawQuery that

--- a/internal/http/static/assets/scripts/app.js
+++ b/internal/http/static/assets/scripts/app.js
@@ -156,6 +156,12 @@
     }
   });
 
+  document.addEventListener('change', (e) => {
+    const t = e.target.closest('[data-autosubmit]');
+    if (!t || !t.form) return;
+    t.form.submit();
+  });
+
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' || e.key === ' ') {
       const t = e.target.closest && e.target.closest('[data-toggle-next]');

--- a/internal/http/templates/closures.html
+++ b/internal/http/templates/closures.html
@@ -42,6 +42,18 @@ An event is recorded when <strong>2 or more plugins</strong> from the same vendo
 <div class="max-w-4xl">
 
 {{if .Events}}
+<form method="GET" action="/closures" class="flex justify-end mb-4">
+<label for="closures-sort" class="sr-only">Sort by</label>
+<div class="relative">
+<svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"/></svg>
+<select id="closures-sort" name="sort" data-autosubmit class="h-10 pl-9 pr-8 text-sm border border-gray-200 rounded-lg bg-white select-chevron focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary">
+<option value="recent"{{if eq .Sort "recent"}} selected{{end}}>Most recent</option>
+<option value="closures"{{if eq .Sort "closures"}} selected{{end}}>Most closures</option>
+</select>
+</div>
+<button type="submit" class="sr-only">Sort</button>
+</form>
+
 <div class="rounded-xl border border-gray-200/60 overflow-hidden">
 <ul role="list" class="divide-y divide-gray-200/60">
 {{range .Events}}
@@ -78,9 +90,9 @@ Detected {{timeAgo (.DetectedAt.Format "2006-01-02T15:04:05Z")}}
 
 {{if gt .TotalPages 1}}
 <div class="flex justify-center items-center gap-1 pt-8">
-{{if gt .Page 1}}<a href="/closures?page={{sub .Page 1}}" class="inline-flex items-center gap-1 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-500 hover:bg-gray-50 hover:text-gray-900 transition-colors cursor-pointer"><svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5"/></svg>Previous</a>{{else}}<span class="inline-flex items-center gap-1 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-300 cursor-default"><svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5"/></svg>Previous</span>{{end}}
-{{range pageRange .Page .TotalPages}}{{if eq . 0}}<span class="min-w-9 h-9 px-2 inline-flex items-center justify-center text-sm text-gray-400">...</span>{{else if eq . $.Page}}<span class="min-w-9 h-9 px-2 inline-flex items-center justify-center border border-gray-200 rounded-lg text-sm font-medium text-gray-900 bg-gray-50">{{.}}</span>{{else}}<a href="/closures?page={{.}}" class="min-w-9 h-9 px-2 inline-flex items-center justify-center border border-gray-200 rounded-lg text-sm text-gray-500 hover:bg-gray-50 hover:text-gray-900 transition-colors cursor-pointer">{{.}}</a>{{end}}{{end}}
-{{if lt .Page .TotalPages}}<a href="/closures?page={{add .Page 1}}" class="inline-flex items-center gap-1 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-500 hover:bg-gray-50 hover:text-gray-900 transition-colors cursor-pointer">Next<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"/></svg></a>{{else}}<span class="inline-flex items-center gap-1 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-300 cursor-default">Next<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"/></svg></span>{{end}}
+{{if gt .Page 1}}<a href="/closures?page={{sub .Page 1}}{{if eq $.Sort "closures"}}&sort=closures{{end}}" class="inline-flex items-center gap-1 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-500 hover:bg-gray-50 hover:text-gray-900 transition-colors cursor-pointer"><svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5"/></svg>Previous</a>{{else}}<span class="inline-flex items-center gap-1 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-300 cursor-default"><svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5"/></svg>Previous</span>{{end}}
+{{range pageRange .Page .TotalPages}}{{if eq . 0}}<span class="min-w-9 h-9 px-2 inline-flex items-center justify-center text-sm text-gray-400">...</span>{{else if eq . $.Page}}<span class="min-w-9 h-9 px-2 inline-flex items-center justify-center border border-gray-200 rounded-lg text-sm font-medium text-gray-900 bg-gray-50">{{.}}</span>{{else}}<a href="/closures?page={{.}}{{if eq $.Sort "closures"}}&sort=closures{{end}}" class="min-w-9 h-9 px-2 inline-flex items-center justify-center border border-gray-200 rounded-lg text-sm text-gray-500 hover:bg-gray-50 hover:text-gray-900 transition-colors cursor-pointer">{{.}}</a>{{end}}{{end}}
+{{if lt .Page .TotalPages}}<a href="/closures?page={{add .Page 1}}{{if eq $.Sort "closures"}}&sort=closures{{end}}" class="inline-flex items-center gap-1 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-500 hover:bg-gray-50 hover:text-gray-900 transition-colors cursor-pointer">Next<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"/></svg></a>{{else}}<span class="inline-flex items-center gap-1 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-300 cursor-default">Next<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"/></svg></span>{{end}}
 </div>
 {{end}}
 

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -117,16 +117,23 @@ type ClosurePluginStatus struct {
 	IsClosed    bool   `json:"is_closed"`
 }
 
-func GetClosureEvents(ctx context.Context, db *sql.DB, page, perPage int) ([]ClosureEvent, int, error) {
+// GetClosureEvents returns a page of closure events. sort "closures" orders
+// by number of plugins closed (largest first); any other value orders by
+// most recently detected.
+func GetClosureEvents(ctx context.Context, db *sql.DB, sort string, page, perPage int) ([]ClosureEvent, int, error) {
 	var total int
 	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM closure_events").Scan(&total); err != nil {
 		return nil, 0, err
 	}
 
+	orderBy := "detected_at DESC, id DESC"
+	if sort == "closures" {
+		orderBy = "plugin_count DESC, detected_at DESC, id DESC"
+	}
 	rows, err := db.QueryContext(ctx, `
 		SELECT id, vendor_name, vendor_slug, detected_at, plugin_slugs, plugin_count
 		FROM closure_events
-		ORDER BY detected_at DESC, id DESC
+		ORDER BY `+orderBy+`
 		LIMIT ? OFFSET ?`, perPage, (page-1)*perPage)
 	if err != nil {
 		return nil, 0, err

--- a/internal/packages/package_test.go
+++ b/internal/packages/package_test.go
@@ -645,3 +645,101 @@ func TestAllocateSyncRunID(t *testing.T) {
 		t.Errorf("status = %q, want completed", status)
 	}
 }
+
+func setupClosureEventsTable(t *testing.T, database *sql.DB) {
+	t.Helper()
+	_, err := database.Exec(`
+		CREATE TABLE closure_events (
+			id INTEGER PRIMARY KEY,
+			vendor_name TEXT NOT NULL,
+			vendor_slug TEXT NOT NULL,
+			detected_at DATETIME NOT NULL,
+			plugin_slugs TEXT NOT NULL,
+			plugin_count INTEGER NOT NULL
+		)`)
+	if err != nil {
+		t.Fatalf("creating closure_events table: %v", err)
+	}
+}
+
+func TestGetClosureEventsSort(t *testing.T) {
+	database := setupTestDB(t)
+	setupClosureEventsTable(t, database)
+	ctx := context.Background()
+
+	rows := []struct {
+		vendor   string
+		detected string
+		count    int
+	}{
+		{"Alpha", "2026-01-01T00:00:00Z", 5},
+		{"Beta", "2026-02-01T00:00:00Z", 20},
+		{"Gamma", "2026-03-01T00:00:00Z", 10},
+	}
+	for _, r := range rows {
+		_, err := database.Exec(
+			`INSERT INTO closure_events (vendor_name, vendor_slug, detected_at, plugin_slugs, plugin_count)
+			 VALUES (?, ?, ?, '["a","b"]', ?)`,
+			r.vendor, r.vendor, r.detected, r.count)
+		if err != nil {
+			t.Fatalf("inserting closure event: %v", err)
+		}
+	}
+
+	assertOrder := func(sort string, want []string) {
+		t.Helper()
+		events, total, err := GetClosureEvents(ctx, database, sort, 1, 10)
+		if err != nil {
+			t.Fatalf("GetClosureEvents(%q): %v", sort, err)
+		}
+		if total != 3 {
+			t.Errorf("total = %d, want 3", total)
+		}
+		var got []string
+		for _, e := range events {
+			got = append(got, e.VendorName)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("sort %q: got %v, want %v", sort, got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("sort %q: got %v, want %v", sort, got, want)
+			}
+		}
+	}
+
+	assertOrder("recent", []string{"Gamma", "Beta", "Alpha"})
+	assertOrder("", []string{"Gamma", "Beta", "Alpha"})
+	assertOrder("closures", []string{"Beta", "Gamma", "Alpha"})
+}
+
+func TestGetClosureEventsSortTiesBreakByRecency(t *testing.T) {
+	database := setupTestDB(t)
+	setupClosureEventsTable(t, database)
+	ctx := context.Background()
+
+	for _, r := range []struct {
+		vendor   string
+		detected string
+	}{
+		{"Older", "2026-01-01T00:00:00Z"},
+		{"Newer", "2026-02-01T00:00:00Z"},
+	} {
+		_, err := database.Exec(
+			`INSERT INTO closure_events (vendor_name, vendor_slug, detected_at, plugin_slugs, plugin_count)
+			 VALUES (?, ?, ?, '["a","b"]', 7)`,
+			r.vendor, r.vendor, r.detected)
+		if err != nil {
+			t.Fatalf("inserting closure event: %v", err)
+		}
+	}
+
+	events, _, err := GetClosureEvents(ctx, database, "closures", 1, 10)
+	if err != nil {
+		t.Fatalf("GetClosureEvents: %v", err)
+	}
+	if len(events) != 2 || events[0].VendorName != "Newer" {
+		t.Errorf("expected Newer first on equal plugin_count, got %+v", events)
+	}
+}


### PR DESCRIPTION
The mass closure history page is now paginated on production, so finding the biggest events means paging through chronologically. This adds a sort control matching the front page's, with two options: **Most recent** (default, unchanged behavior) and **Most closures** (`plugin_count DESC`, recency as tiebreaker).

- `GET /closures?sort=closures` — new whitelisted `sort` param; invalid values fall back to `recent`
- Sort select above the event list, styled like the front page's, auto-submits on change via a reusable `data-autosubmit` handler in app.js (sr-only submit button as no-JS fallback)
- Pagination links preserve the active sort
- `GET /api/closures` accepts the same param and echoes `"sort"` in the response
- `/closures.md` sibling supports it too (`sort` added to `mdContentParams`); the events heading notes the active sort
- RSS feed stays recency-ordered
- Tests cover both sort orders and the equal-count tiebreak

🤖 Generated with [Claude Code](https://claude.com/claude-code)