### PR TITLE
Keep packages dirty while a stable release awaits wp.org publication

### DIFF
--- a/cmd/wppackages/cmd/update.go
+++ b/cmd/wppackages/cmd/update.go
@@ -20,6 +20,12 @@ import (
 // Set high (24h) to account for extended wp.org API cache delays.
 const staleRetryWindow = 24 * time.Hour
 
+// pendingStableRetryWindow is how long to keep retrying a theme whose SVN tags
+// include a stable version above what the wp.org directory reports as current.
+// Theme updates sit in a review queue after the tag lands, routinely for days,
+// so the standard window would expire before the release goes live.
+const pendingStableRetryWindow = 7 * 24 * time.Hour
+
 var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Fetch and update package metadata from WordPress.org",
@@ -152,7 +158,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			pkg := packages.PackageFromAPIData(data, p.Type)
 			pkg.ID = p.ID
 
-			validVersions, err := pkg.NormalizeAndStoreVersions()
+			validVersions, pendingStable, err := pkg.NormalizeAndStoreVersions()
 			if err != nil {
 				application.Logger.Warn("version normalization failed", "type", p.Type, "name", p.Name, "error", err)
 				failed.Add(1)
@@ -177,7 +183,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			now := time.Now().UTC()
 			pkg.LastSyncRunID = &syncRun.RunID
 
-			decision := shouldAdvanceSyncedAt(pkg.VersionsJSON, p.VersionsJSON, p.LastCommitted, now)
+			decision := shouldAdvanceSyncedAt(pkg.VersionsJSON, p.VersionsJSON, pendingStable, p.Type, p.LastCommitted, now)
 			if pkg.VersionsJSON != p.VersionsJSON {
 				changed.Add(1)
 			}
@@ -266,14 +272,28 @@ const (
 )
 
 // shouldAdvanceSyncedAt decides whether to advance last_synced_at after an update.
-// If versions changed, always advance. If unchanged, keep dirty within the retry
-// window to handle wp.org API cache delays. After the window, advance to avoid
-// infinite retries from non-version SVN changes (readme, assets).
-func shouldAdvanceSyncedAt(newVersions, oldVersions string, lastCommitted *time.Time, now time.Time) syncDecision {
+// A pending stable release (a tag above the wp.org stable version, awaiting
+// directory publication) keeps the package dirty within its retry window even
+// when versions changed — the change may be an incidental catch-up from an
+// earlier commit, and advancing would strand the package on the old version
+// once the release goes live. Otherwise: if versions changed, advance; if
+// unchanged, keep dirty within the retry window to handle wp.org API cache
+// delays, then advance to avoid infinite retries from non-version SVN changes
+// (readme, assets).
+func shouldAdvanceSyncedAt(newVersions, oldVersions string, pendingStable bool, pkgType string, lastCommitted *time.Time, now time.Time) syncDecision {
+	window := staleRetryWindow
+	if pendingStable && pkgType == "theme" {
+		window = pendingStableRetryWindow
+	}
+	withinWindow := lastCommitted != nil && now.Sub(*lastCommitted) <= window
+
+	if pendingStable && withinWindow {
+		return syncRetry
+	}
 	if newVersions != oldVersions {
 		return syncAdvance
 	}
-	if lastCommitted != nil && now.Sub(*lastCommitted) <= staleRetryWindow {
+	if withinWindow {
 		return syncRetry
 	}
 	return syncExpire

--- a/cmd/wppackages/cmd/update_test.go
+++ b/cmd/wppackages/cmd/update_test.go
@@ -10,7 +10,7 @@ func TestShouldAdvanceSyncedAt(t *testing.T) {
 
 	t.Run("versions changed", func(t *testing.T) {
 		committed := now.Add(-5 * time.Minute)
-		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{}`, &committed, now)
+		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{}`, false, "plugin", &committed, now)
 		if got != syncAdvance {
 			t.Errorf("got %d, want syncAdvance", got)
 		}
@@ -18,7 +18,7 @@ func TestShouldAdvanceSyncedAt(t *testing.T) {
 
 	t.Run("versions unchanged within window", func(t *testing.T) {
 		committed := now.Add(-10 * time.Minute)
-		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{"1.0":"url"}`, &committed, now)
+		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{"1.0":"url"}`, false, "plugin", &committed, now)
 		if got != syncRetry {
 			t.Errorf("got %d, want syncRetry", got)
 		}
@@ -26,14 +26,14 @@ func TestShouldAdvanceSyncedAt(t *testing.T) {
 
 	t.Run("versions unchanged after window", func(t *testing.T) {
 		committed := now.Add(-25 * time.Hour)
-		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{"1.0":"url"}`, &committed, now)
+		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{"1.0":"url"}`, false, "plugin", &committed, now)
 		if got != syncExpire {
 			t.Errorf("got %d, want syncExpire", got)
 		}
 	})
 
 	t.Run("versions unchanged nil last_committed", func(t *testing.T) {
-		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{"1.0":"url"}`, nil, now)
+		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{"1.0":"url"}`, false, "plugin", nil, now)
 		if got != syncExpire {
 			t.Errorf("got %d, want syncExpire", got)
 		}
@@ -41,7 +41,7 @@ func TestShouldAdvanceSyncedAt(t *testing.T) {
 
 	t.Run("versions unchanged at window boundary", func(t *testing.T) {
 		committed := now.Add(-staleRetryWindow)
-		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{"1.0":"url"}`, &committed, now)
+		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{"1.0":"url"}`, false, "plugin", &committed, now)
 		if got != syncRetry {
 			t.Errorf("got %d, want syncRetry (at boundary)", got)
 		}
@@ -49,9 +49,55 @@ func TestShouldAdvanceSyncedAt(t *testing.T) {
 
 	t.Run("versions unchanged just past window", func(t *testing.T) {
 		committed := now.Add(-staleRetryWindow - 1*time.Second)
-		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{"1.0":"url"}`, &committed, now)
+		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{"1.0":"url"}`, false, "plugin", &committed, now)
 		if got != syncExpire {
 			t.Errorf("got %d, want syncExpire (just past window)", got)
+		}
+	})
+
+	// The neve case: the sync triggered by a new tag's commit picks up an
+	// incidental change (a previous release finally going live) while the new
+	// tag itself is still filtered out as above-stable. Advancing here would
+	// strand the package once the release is published.
+	t.Run("pending stable overrides versions changed", func(t *testing.T) {
+		committed := now.Add(-5 * time.Minute)
+		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{}`, true, "theme", &committed, now)
+		if got != syncRetry {
+			t.Errorf("got %d, want syncRetry", got)
+		}
+	})
+
+	t.Run("pending stable theme uses extended window", func(t *testing.T) {
+		committed := now.Add(-3 * 24 * time.Hour)
+		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{"1.0":"url"}`, true, "theme", &committed, now)
+		if got != syncRetry {
+			t.Errorf("got %d, want syncRetry (3 days is within theme window)", got)
+		}
+	})
+
+	t.Run("pending stable theme past extended window", func(t *testing.T) {
+		committed := now.Add(-pendingStableRetryWindow - 1*time.Second)
+		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{"1.0":"url"}`, true, "theme", &committed, now)
+		if got != syncExpire {
+			t.Errorf("got %d, want syncExpire (past extended window)", got)
+		}
+	})
+
+	// Plugins keep the standard window even with a pending stable: a stable
+	// tag above the Stable Tag is often intentional there, not directory lag.
+	t.Run("pending stable plugin keeps standard window", func(t *testing.T) {
+		committed := now.Add(-25 * time.Hour)
+		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{}`, true, "plugin", &committed, now)
+		if got != syncAdvance {
+			t.Errorf("got %d, want syncAdvance (past standard window, versions changed)", got)
+		}
+	})
+
+	t.Run("pending stable plugin within standard window", func(t *testing.T) {
+		committed := now.Add(-10 * time.Minute)
+		got := shouldAdvanceSyncedAt(`{"1.0":"url"}`, `{}`, true, "plugin", &committed, now)
+		if got != syncRetry {
+			t.Errorf("got %d, want syncRetry", got)
 		}
 	})
 }

--- a/internal/integration/wporg_live_test.go
+++ b/internal/integration/wporg_live_test.go
@@ -84,7 +84,7 @@ func TestWpOrgLive(t *testing.T) {
 
 		pkg := packages.PackageFromAPIData(data, p.Type)
 		pkg.ID = p.ID
-		if _, err := pkg.NormalizeAndStoreVersions(); err != nil {
+		if _, _, err := pkg.NormalizeAndStoreVersions(); err != nil {
 			t.Fatalf("normalize %s: %v", p.Name, err)
 		}
 		pkg.LastSyncRunID = &syncRun.RunID

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -68,21 +68,27 @@ type Package struct {
 
 // NormalizeAndStoreVersions normalizes raw versions and serializes to VersionsJSON.
 // It also sets CurrentVersion to the highest published version.
-// Returns the number of valid versions.
-func (p *Package) NormalizeAndStoreVersions() (int, error) {
+// Returns the number of valid versions and whether FilterNewerThan dropped a
+// stable version — i.e. a tag exists above the wp.org stable version, which
+// means a release is likely awaiting directory publication and the package
+// should be re-synced rather than considered up to date.
+func (p *Package) NormalizeAndStoreVersions() (int, bool, error) {
 	if p.RawVersions == nil {
 		p.VersionsJSON = "{}"
-		return 0, nil
+		return 0, false, nil
 	}
 
 	normalized := version.NormalizeVersions(p.RawVersions)
+	pendingStable := false
 	if p.WporgVersion != nil {
+		before := len(normalized)
 		normalized = version.FilterNewerThan(normalized, *p.WporgVersion)
+		pendingStable = len(normalized) < before
 	}
 
 	data, err := json.Marshal(normalized)
 	if err != nil {
-		return 0, fmt.Errorf("marshaling versions: %w", err)
+		return 0, false, fmt.Errorf("marshaling versions: %w", err)
 	}
 	p.VersionsJSON = string(data)
 
@@ -90,7 +96,7 @@ func (p *Package) NormalizeAndStoreVersions() (int, error) {
 		p.CurrentVersion = &latest
 	}
 
-	return len(normalized), nil
+	return len(normalized), pendingStable, nil
 }
 
 func timeStr(t *time.Time) *string {

--- a/internal/packages/package_test.go
+++ b/internal/packages/package_test.go
@@ -172,12 +172,15 @@ func TestNormalizeAndStoreVersionsUsesWporgVersion(t *testing.T) {
 		},
 	}
 
-	count, err := pkg.NormalizeAndStoreVersions()
+	count, pendingStable, err := pkg.NormalizeAndStoreVersions()
 	if err != nil {
 		t.Fatalf("normalizing versions: %v", err)
 	}
 	if count != 3 {
 		t.Fatalf("NormalizeAndStoreVersions returned %d entries, want 3", count)
+	}
+	if !pendingStable {
+		t.Fatal("pendingStable = false, want true (10.8.0 was filtered out)")
 	}
 	if pkg.CurrentVersion == nil || *pkg.CurrentVersion != "10.7.0" {
 		t.Fatalf("CurrentVersion = %v, want 10.7.0", pkg.CurrentVersion)

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -95,7 +95,7 @@ func SeedFromFixtures(t *testing.T, database *sql.DB, mockURL string) {
 
 		pkg := packages.PackageFromAPIData(data, p.Type)
 		pkg.ID = p.ID
-		if _, err := pkg.NormalizeAndStoreVersions(); err != nil {
+		if _, _, err := pkg.NormalizeAndStoreVersions(); err != nil {
 			t.Fatalf("normalizing versions for %s: %v", p.Name, err)
 		}
 		now := time.Now().UTC()


### PR DESCRIPTION
## Problem

`wp-theme/neve` 4.2.8 was tagged in SVN on July 8 (r337903) and went live on wp.org on July 9, but wp-packages stayed stranded at 4.2.7. The timeline from the production DB:

1. SVN changelog detection correctly marked neve changed at 13:01:33 UTC, one minute after the tag landed
2. The sync one second later fetched the themes API, which still reported 4.2.7 as current — the 4.2.8 release was sitting in wp.org's publication queue — so `FilterNewerThan` stripped 4.2.8 as above-stable (#112)
3. That same sync observed an incidental versions change (belatedly picking up 4.2.7, which had lagged from its own June 30 tag), so `shouldAdvanceSyncedAt` took the `syncAdvance` path and marked the package fully synced
4. With `last_committed <= last_synced_at` and no SVN commits to `/neve/` since, the package is never re-queued — stranded permanently

The 24h stale-retry window built for wp.org API lag only engages when versions come back *unchanged*; any incidental change disarms it.

## Fix

`NormalizeAndStoreVersions` now reports when the above-stable filter dropped a stable version — direct evidence that a tagged release is awaiting directory publication. `shouldAdvanceSyncedAt` keeps such packages in retry even when versions changed, so they're re-synced until the release goes live or the window expires.

Themes get a 7-day `pendingStableRetryWindow`, since the theme review queue routinely lags days behind the tag (neve's 4.2.7 took ~8 days from tag to live). Plugins keep the 24h window: an above-stable tag there is usually an intentional Stable Tag choice, not lag.

On each retry the freshly fetched `versions_json` is still written and deployed — only `last_synced_at` is held back. Retried packages with unchanged content hash identically and never enter the dirty set, so build/deploy workload is unaffected.

## Rollout

After deploying, run `wppackages update --force` once to heal already-stranded packages — the API now serves correct versions for everything stranded by this bug. The next scheduled pipeline's build/deploy picks up the changes automatically; unchanged packages hash identically and are skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ref https://discourse.roots.io/t/wp-packages-missing-update-from-neve/30398