### PR TITLE
Re-sync packages after reactivation

### DIFF
--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -595,11 +595,20 @@ func MarkPermanentlyClosed(ctx context.Context, db *sql.DB, id int64) error {
 	return nil
 }
 
-// ReactivatePackage sets is_active = 1 for a package.
+// ReactivatePackage sets is_active = 1 for a package and clears last_synced_at
+// so the next update re-syncs it.
+//
+// While a package is inactive, MarkPackagesChanged skips it (it filters on
+// is_active = 1), so every SVN commit landing in that window is discarded and
+// last_committed never advances. Reactivating without clearing the sync state
+// would leave last_committed <= last_synced_at — permanently "clean" — and the
+// package would sit at its pre-closure versions until its next release happened
+// to be committed. GetPackagesNeedingUpdate treats a NULL last_synced_at as
+// needing an update and orders those first.
 func ReactivatePackage(ctx context.Context, db *sql.DB, id int64) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	_, err := db.ExecContext(ctx,
-		`UPDATE packages SET is_active = 1, updated_at = ?, content_changed_at = ? WHERE id = ?`,
+		`UPDATE packages SET is_active = 1, last_synced_at = NULL, updated_at = ?, content_changed_at = ? WHERE id = ?`,
 		now, now, id,
 	)
 	if err != nil {

--- a/internal/packages/package_test.go
+++ b/internal/packages/package_test.go
@@ -481,6 +481,75 @@ func TestReactivatePackage(t *testing.T) {
 	}
 }
 
+// TestReactivatedPackageIsRequeued covers the closure/reopen lifecycle that
+// stranded a batch of plugins at their pre-closure versions: a package is
+// deactivated while wp.org has it closed, releases are tagged in SVN during
+// that window, and the package is later reopened. MarkPackagesChanged only
+// touches active rows, so those commits are lost and last_committed stays
+// behind last_synced_at. Reactivation must therefore clear last_synced_at,
+// otherwise the row looks permanently up to date and never re-syncs.
+func TestReactivatedPackageIsRequeued(t *testing.T) {
+	database := setupTestDB(t)
+	ctx := context.Background()
+
+	committed := time.Date(2026, 3, 23, 0, 0, 0, 0, time.UTC)
+	synced := time.Date(2026, 3, 26, 0, 0, 0, 0, time.UTC)
+	if err := UpsertPackage(ctx, database, &Package{
+		Type: "plugin", Name: "closed-then-reopened", VersionsJSON: `{"1.0.0":"url"}`,
+		IsActive: true, LastCommitted: &committed, LastSyncedAt: &synced,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	var id int64
+	if err := database.QueryRow("SELECT id FROM packages WHERE name='closed-then-reopened'").Scan(&id); err != nil {
+		t.Fatalf("select id: %v", err)
+	}
+
+	// wp.org closes the plugin; check-status deactivates it.
+	if err := DeactivatePackage(ctx, database, id); err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+
+	// A release is tagged in SVN while the package is inactive. The changelog
+	// scan sees the slug but MarkPackagesChanged filters on is_active = 1, so
+	// the commit is silently dropped and last_committed does not advance.
+	affected, err := MarkPackagesChanged(ctx, database, "plugin", map[string]int64{"closed-then-reopened": 3613892})
+	if err != nil {
+		t.Fatalf("mark changed: %v", err)
+	}
+	if affected != 0 {
+		t.Fatalf("MarkPackagesChanged affected %d rows, want 0 (package is inactive)", affected)
+	}
+
+	// wp.org reopens the plugin; check-status reactivates it.
+	if err := ReactivatePackage(ctx, database, id); err != nil {
+		t.Fatalf("reactivate: %v", err)
+	}
+
+	var lastSyncedAt *string
+	if err := database.QueryRow("SELECT last_synced_at FROM packages WHERE id=?", id).Scan(&lastSyncedAt); err != nil {
+		t.Fatalf("select last_synced_at: %v", err)
+	}
+	if lastSyncedAt != nil {
+		t.Errorf("last_synced_at = %q after reactivation, want NULL", *lastSyncedAt)
+	}
+
+	pkgs, err := GetPackagesNeedingUpdate(ctx, database, UpdateQueryOpts{})
+	if err != nil {
+		t.Fatalf("querying packages needing update: %v", err)
+	}
+	var found bool
+	for _, p := range pkgs {
+		if p.Name == "closed-then-reopened" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("reactivated package should be queued for update")
+	}
+}
+
 func TestBatchUpsertShellPackages(t *testing.T) {
 	database := setupTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
A package deactivated by check-status (wp.org closure) loses every SVN commit that lands while it's inactive — MarkPackagesChanged filters on is_active = 1. ReactivatePackage set is_active back to 1 but left last_synced_at alone, so the row came back with last_committed <= last_synced_at, looked up to date, and was never re-queued. `update --force` didn't reach these either, since it also filters on is_active = 1.

ReactivatePackage now clears last_synced_at. GetPackagesNeedingUpdate selects on `last_synced_at IS NULL` and orders NULLS FIRST, so a reopened package is picked up on the next pipeline tick.

Production currently has 16 active plugins frozen this way, four of them from the same vendor closure wave — wp-plugin/wholesale-pricing-woocommerce is reported at 4.0.5 with 4.0.6 and 4.1.0 tagged in SVN since May and July. `update --force` heals them now that they're active again.

One consideration: a large reopening wave (run 1678 reactivated 67064 packages in March) would enqueue that many at once. Same volume as a force run, which completes fine, but it makes for one long pipeline tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
