### PR TITLE
Go: Upgrade to v1.27.1

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Go 1.26+
+- Go 1.27+
 - [air](https://github.com/air-verse/air) — `go install github.com/air-verse/air@latest`
 - [golangci-lint](https://github.com/golangci/golangci-lint) — `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest` (for `make lint`)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/roots/wp-packages
 
-go 1.26.5
+go 1.27.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.6


### PR DESCRIPTION
1. To include v1.26.6 & v1.26.7 bug fixes
2. Prepare for [encoding/json/v2 and encoding/json/jsontext packages](https://go.dev/doc/go1.27#jsonv2)
3. (unverified, maybe beneficial) [Better HTTP connection reuse](https://go.dev/doc/go1.27#nethttppkgnethttp)